### PR TITLE
[Feat] Create My Info

### DIFF
--- a/member/pom.xml
+++ b/member/pom.xml
@@ -66,12 +66,12 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.6.1</version>
+            <version>2.9.2</version>
         </dependency>
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>
-            <version>2.6.1</version>
+            <version>2.9.2</version>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>

--- a/member/src/main/java/kr/or/dining_together/member/advice/ExceptionAdvice.java
+++ b/member/src/main/java/kr/or/dining_together/member/advice/ExceptionAdvice.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import kr.or.dining_together.member.advice.exception.AuthenticationEntryPointException;
 import kr.or.dining_together.member.advice.exception.LoginFailedException;
+import kr.or.dining_together.member.advice.exception.PasswordNotMatchedException;
 import kr.or.dining_together.member.advice.exception.UserNotFoundException;
 import kr.or.dining_together.member.model.CommonResult;
 import kr.or.dining_together.member.service.ResponseService;
@@ -43,6 +44,13 @@ public class ExceptionAdvice {
 	public CommonResult authenticationEntryPointException(HttpServletRequest request,
 		AuthenticationEntryPointException e) {
 		return responseService.getFailResult(401, "권한이 없습니다");
+	}
+
+	@ExceptionHandler(PasswordNotMatchedException.class)
+	@ResponseStatus(HttpStatus.UNAUTHORIZED)
+	public CommonResult passwordNotMatchedException(HttpServletRequest request,
+		AuthenticationEntryPointException e) {
+		return responseService.getFailResult(400, "패스워드가 맞지 않습니다.");
 	}
 
 }

--- a/member/src/main/java/kr/or/dining_together/member/advice/exception/PasswordNotMatchedException.java
+++ b/member/src/main/java/kr/or/dining_together/member/advice/exception/PasswordNotMatchedException.java
@@ -1,0 +1,15 @@
+package kr.or.dining_together.member.advice.exception;
+
+public class PasswordNotMatchedException extends RuntimeException {
+	public PasswordNotMatchedException() {
+		super();
+	}
+
+	public PasswordNotMatchedException(String message) {
+		super(message);
+	}
+
+	public PasswordNotMatchedException(String message, Throwable t) {
+		super(message, t);
+	}
+}

--- a/member/src/main/java/kr/or/dining_together/member/config/SwaggerConfig.java
+++ b/member/src/main/java/kr/or/dining_together/member/config/SwaggerConfig.java
@@ -11,6 +11,15 @@ import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
+/**
+ * @package : kr.or.dining_together.member.config
+ * @name: SwaggerConfig.java
+ * @date : 2021/05/26 12:44 오전
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description : swagger 설정 파일
+ * @modified :
+ **/
 @Configuration
 @EnableSwagger2
 public class SwaggerConfig {
@@ -19,7 +28,7 @@ public class SwaggerConfig {
 	public Docket swaggerApi() {
 		return new Docket(DocumentationType.SWAGGER_2).apiInfo(swaggerInfo()).select()
 			.apis(RequestHandlerSelectors.basePackage("kr.or.dining_together.member.controller"))
-			.paths(PathSelectors.ant("/auth/**"))
+			.paths(PathSelectors.ant("/member/**"))
 			.build()
 			.useDefaultResponseMessages(false); // 기본으로 세팅되는 200,401,403,404 메시지를 표시 하지 않음
 	}

--- a/member/src/main/java/kr/or/dining_together/member/config/WebSecurityConfig.java
+++ b/member/src/main/java/kr/or/dining_together/member/config/WebSecurityConfig.java
@@ -16,6 +16,15 @@ import kr.or.dining_together.member.config.security.JwtAuthenticationFilter;
 import kr.or.dining_together.member.config.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * @package : kr.or.dining_together.member.config
+ * @name: WebSecurityConfig.java
+ * @date : 2021/05/26 12:45 오전
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description : 스프링 시큐리티 설정 파일
+ * @modified :
+ **/
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor

--- a/member/src/main/java/kr/or/dining_together/member/controller/SignController.java
+++ b/member/src/main/java/kr/or/dining_together/member/controller/SignController.java
@@ -19,14 +19,20 @@ import kr.or.dining_together.member.service.UserService;
 import kr.or.dining_together.member.vo.LoginRequest;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * @package : kr.or.dining_together.member.controller
+ * @name: SignController.java
+ * @date : 2021/05/30 12:43 오전
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description : 로그인 회원가입
+ * @modified :
+ **/
 @Api(tags = {"1. Sign"})
 @RequiredArgsConstructor
 @RestController
 @RequestMapping(value = "/member/auth")
 public class SignController {
-	/*
-	로그인 회원가입 로직
-	 */
 	private final UserRepository userRepository;
 	private final JwtTokenProvider jwtTokenProvider;
 	private final ResponseService responseService;

--- a/member/src/main/java/kr/or/dining_together/member/controller/UserController.java
+++ b/member/src/main/java/kr/or/dining_together/member/controller/UserController.java
@@ -1,15 +1,104 @@
 package kr.or.dining_together.member.controller;
 
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import kr.or.dining_together.member.dto.UserDto;
+import kr.or.dining_together.member.model.CommonResult;
+import kr.or.dining_together.member.model.SingleResult;
+import kr.or.dining_together.member.service.ResponseService;
+import kr.or.dining_together.member.service.UserService;
+import kr.or.dining_together.member.vo.PasswordRequest;
+import lombok.RequiredArgsConstructor;
 
-@Api(tags = {"1. User"})
+/**
+ * @package : kr.or.dining_together.member.controller
+ * @name: UserController.java
+ * @date : 2021/05/30 12:42 오전
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description : 마이페이지 내 정보
+ * @modified :
+ **/
+@Api(tags = {"2. User"})
+@RequiredArgsConstructor
 @RestController
-@RequestMapping(value = "/auth")
+@RequestMapping(value = "/member")
 public class UserController {
-    /*
-    내정보
-     */
+
+	private final UserService userService;
+	private final ResponseService responseService;
+
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "X-AUTH-TOKEN", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")
+	})
+	@ApiOperation(value = "회원 정보 조회", notes = "회원 단건 조회")
+	@GetMapping(value = "/user")
+	public SingleResult<UserDto> findUser() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		String email = authentication.getName();
+
+		return responseService.getSingleResult(userService.getUser(email));
+	}
+	//
+	// @ApiImplicitParams({
+	// 	@ApiImplicitParam(name = "X-AUTH-TOKEN", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")
+	// })
+	// @ApiOperation(value = "업체 정보 조회", notes = "업체 단건 조회")
+	// @GetMapping(value = "/store")
+	// public SingleResult<UserDto> findUser() {
+	// 	Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+	// 	String email = authentication.getName();
+	//
+	// 	return responseService.getSingleResult(userService.getUser(email));
+	// }
+
+	// @ApiOperation(value="회원 정보 수정")
+	// @ApiImplicitParams({
+	// 	@ApiImplicitParam(name = "X-AUTH-TOKEN", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")
+	// })
+	// @PutMapping(value="/user")
+	// public SingleResult<UserDto> modify(@RequestBody UserDto userDto){
+	// 	Authentication authentication= SecurityContextHolder.getContext().getAuthentication();
+	// 	String email=authentication.getName();
+	// 	return responseService.getSingleResult(userService.modify(userDto,email));
+	// }
+	@ApiOperation(value = "회원 탈퇴")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "X-AUTH-TOKEN", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")
+	})
+	@DeleteMapping(value = "/user")
+	public CommonResult delete() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		String email = authentication.getName();
+		userService.delete(email);
+		return responseService.getSuccessResult();
+	}
+
+	@ApiOperation(value = "비밀번호 변경")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "X-AUTH-TOKEN", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")
+	})
+	@PutMapping(value = "/password")
+	public CommonResult changePassword(
+		@RequestBody @ApiParam(value = "비밀번호 변경", required = true) PasswordRequest passwordRequest) {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		String email = authentication.getName();
+		if (userService.isValidPassword(email, passwordRequest)) {
+			userService.updatePassword(email, passwordRequest);
+		}
+		return responseService.getSuccessResult();
+	}
+
 }

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/User.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/User.java
@@ -113,4 +113,12 @@ public class User implements UserDetails {
 	public boolean isEnabled() {
 		return true;
 	}
+
+	//수정용
+	//public User update()
+
+	public void updatePassword(String password) {
+		this.password = password;
+	}
+
 }

--- a/member/src/main/java/kr/or/dining_together/member/service/UserService.java
+++ b/member/src/main/java/kr/or/dining_together/member/service/UserService.java
@@ -5,10 +5,13 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import kr.or.dining_together.member.advice.exception.LoginFailedException;
+import kr.or.dining_together.member.advice.exception.PasswordNotMatchedException;
+import kr.or.dining_together.member.advice.exception.UserNotFoundException;
 import kr.or.dining_together.member.dto.UserDto;
 import kr.or.dining_together.member.jpa.entity.User;
 import kr.or.dining_together.member.jpa.repo.UserRepository;
 import kr.or.dining_together.member.vo.LoginRequest;
+import kr.or.dining_together.member.vo.PasswordRequest;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -35,5 +38,37 @@ public class UserService {
 			.roles(userDto.getRoles())
 			.build()).getId();
 	}
+
+	public UserDto getUser(String email) {
+		User user = userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
+		return modelMapper.map(user, UserDto.class);
+
+	}
+
+	public void delete(String email) {
+		User user = userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
+		userRepository.deleteById(user.getId());
+
+	}
+
+	public boolean isValidPassword(String email, PasswordRequest passwordRequest) {
+		User user = userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
+		if (passwordEncoder.matches(passwordRequest.getOldPassword(), user.getPassword())) {
+			return true;
+		} else {
+			throw new PasswordNotMatchedException();
+		}
+
+	}
+
+	public void updatePassword(String email, PasswordRequest passwordRequest) {
+		User user = userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
+		user.updatePassword(passwordEncoder.encode(passwordRequest.getNewPassword()));
+	}
+
+	// public UserDto modify(UserDto userDto,String email) {
+	// 	User user=userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
+	//
+	// }
 
 }

--- a/member/src/main/java/kr/or/dining_together/member/vo/PasswordRequest.java
+++ b/member/src/main/java/kr/or/dining_together/member/vo/PasswordRequest.java
@@ -1,0 +1,20 @@
+package kr.or.dining_together.member.vo;
+
+import javax.validation.constraints.NotEmpty;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordRequest {
+
+	@NotEmpty
+	private String oldPassword;
+
+	@NotEmpty
+	private String newPassword;
+
+}

--- a/member/src/main/resources/application.yml
+++ b/member/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
       url: jdbc:h2:mem:testdb
     jpa:
       hibernate:
-        ddl-auto: create
+        ddl-auto: update
       properties:
         hibernate:
           format_sql: true

--- a/member/src/test/java/kr/or/dining_together/member/controller/SignControllerTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/controller/SignControllerTest.java
@@ -69,7 +69,7 @@ public class SignControllerTest {
 		//given
 		String content = objectMapper.writeValueAsString(new LoginRequest("jifrozen@naver.com", "test1111"));
 		//when//then
-		mockMvc.perform(post("/auth/user")
+		mockMvc.perform(post("/member/auth/signin")
 			.content(content)
 			.contentType(MediaType.APPLICATION_JSON)
 			.accept(MediaType.APPLICATION_JSON))
@@ -95,7 +95,7 @@ public class SignControllerTest {
 		String content = gson.toJson(userDto);
 
 		//when//then
-		mockMvc.perform(post("/auth/user/registeration")
+		mockMvc.perform(post("/member/auth/signup")
 			.content(content)
 			.contentType(MediaType.APPLICATION_JSON)
 			.accept(MediaType.APPLICATION_JSON))

--- a/member/src/test/java/kr/or/dining_together/member/controller/UserControllerTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/controller/UserControllerTest.java
@@ -1,0 +1,141 @@
+package kr.or.dining_together.member.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.Optional;
+
+import javax.transaction.Transactional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.json.JacksonJsonParser;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import kr.or.dining_together.member.jpa.entity.User;
+import kr.or.dining_together.member.jpa.repo.UserRepository;
+import kr.or.dining_together.member.vo.LoginRequest;
+import kr.or.dining_together.member.vo.PasswordRequest;
+
+/**
+ * @package : kr.or.dining_together.member.controller
+ * @name: UserControllerTest.java
+ * @date : 2021/05/30 11:25 오전
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description : UserController Test
+ * @modified :
+ **/
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class UserControllerTest {
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private PasswordEncoder passwordEncoder;
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	private String token;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		User user = User.builder()
+			.id(1L)
+			.email("jifrozen@naver.com")
+			.name("문지언")
+			.password(passwordEncoder.encode("test1111"))
+			.phoneNo("010-1234-5678")
+			.joinDate(new Date())
+			.roles(Collections.singletonList("ROLE_USER"))
+			.build();
+
+		userRepository.save(user);
+
+		String content = objectMapper.writeValueAsString(new LoginRequest("jifrozen@naver.com", "test1111"));
+		//when//then
+		MvcResult result = mockMvc.perform(post("/member/auth/signin")
+			.content(content)
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andReturn();
+
+		String resultTostring = result.getResponse().getContentAsString();
+		JacksonJsonParser jsonParser = new JacksonJsonParser();
+		token = jsonParser.parseMap(resultTostring).get("data").toString();
+
+	}
+
+	@AfterEach
+	public void tearDown() throws Exception {
+	}
+
+	@Test
+	void findUser() throws Exception {
+		mockMvc.perform(MockMvcRequestBuilders
+			.get("/member/user")
+			.header("X-AUTH-TOKEN", token))
+			.andDo(print())
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	void changePassword() throws Exception {
+		//given
+		Optional<User> user = userRepository.findByEmail("jifrozen@naver.com");
+		String content = objectMapper.writeValueAsString(new PasswordRequest("test1111", "test2222"));
+
+		assertTrue(passwordEncoder.matches("test1111", user.get().getPassword()));
+		//when//then
+		mockMvc.perform(put("/member/password")
+			.header("X-AUTH-TOKEN", token)
+			.content(content)
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.msg").exists())
+			.andDo(print());
+
+		assertTrue(passwordEncoder.matches("test2222", user.get().getPassword()));
+
+	}
+
+	@Test
+	void delete() throws Exception {
+		Optional<User> user = userRepository.findByEmail("jifrozen@naver.com");
+		assertTrue(user.isPresent());
+		mockMvc.perform(MockMvcRequestBuilders
+			.delete("/member/user")
+			.header("X-AUTH-TOKEN", token))
+			.andDo(print())
+			.andExpect(status().isOk());
+		assertTrue(userRepository.findByEmail("jifrozen@naver.com").isEmpty());
+	}
+
+}

--- a/member/src/test/java/kr/or/dining_together/member/service/UserServiceTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/service/UserServiceTest.java
@@ -1,6 +1,7 @@
 package kr.or.dining_together.member.service;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -52,6 +53,23 @@ public class UserServiceTest {
 
 		System.out.println(user);
 		System.out.println(userDto);
+	}
+
+	@Test
+	public void updatePassword() {
+
+		User user = User.builder()
+			.id(1L)
+			.email("jifrozen@naver.com")
+			.name("문지언")
+			.password(passwordEncoder.encode("test1111"))
+			.phoneNo("010-1234-5678")
+			.joinDate(new Date())
+			.roles(Collections.singletonList("ROLE_USER"))
+			.build();
+		System.out.println(passwordEncoder.matches("test1111", user.getPassword()));
+		userRepository.save(user);
+
 	}
 
 }


### PR DESCRIPTION
### 1. 회원 정보 단건 조회
GET /member/user

### 2. 회원정보 수정
PUT /member/user
회원 수정은 이메일 비밀번호 제외한 정보를 수정하려고 하는데 
아직 테이블이 완성되지 않아 name밖에 수정할 정보가 없어서 우선 주석처리 했습니다.

### 3. 회원 탈퇴
DELETE /member/user

### 4. 비밀번호 변경
PUT /member/password
기존 비밀번호와 새로운 비밀번호를 passwordRequest로 받아 기존 비밀번호의 유효성 검사 후 새로운 비밀번호로 바꿔주는 식으로 구현을 햇는데
보통 기존 비밀번호 검사 후 새로운 비밀번호 input 활성화해서 바꿔주는 방식이더라고요.
프런트 마이페이지 맡으신분과 의논 후 수정 결정하겠습니다.


### 특이사항
1. @ApiImplicitParams({
		@ApiImplicitParam(name = "X-AUTH-TOKEN", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")
	})
모든 로직이 로그인 성공 토큰을 받아와야하기 때문에 추가했습니다.
따라서 테스트 작성하실때도
mockMvc.perform(put("/member/password")
			.header("X-AUTH-TOKEN", token)
이런식으로 header를 달아줘야합니다.


