### PR TITLE
Entity 수정 && h2 연동 버그 수정

### DIFF
--- a/member/pom.xml
+++ b/member/pom.xml
@@ -33,23 +33,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.modelmapper</groupId>
-            <artifactId>modelmapper</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt</artifactId>
-            <version>0.9.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-security</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-test</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>
@@ -63,6 +46,21 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+        <!-- spring security & jwt token -->
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt</artifactId>
+            <version>0.9.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+        </dependency>
+        <!-- Swagger Api Documentation&UI -->
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
@@ -73,6 +71,7 @@
             <artifactId>springfox-swagger2</artifactId>
             <version>2.6.1</version>
         </dependency>
+        <!-- h2 database -->
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
@@ -83,20 +82,16 @@
             <artifactId>modelmapper</artifactId>
             <version>2.3.8</version>
         </dependency>
+        <!-- unit test library -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- send email -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
         </dependency>
     </dependencies>
     <dependencyManagement>

--- a/member/src/main/java/kr/or/dining_together/member/config/SwaggerConfig.java
+++ b/member/src/main/java/kr/or/dining_together/member/config/SwaggerConfig.java
@@ -19,7 +19,7 @@ public class SwaggerConfig {
 	public Docket swaggerApi() {
 		return new Docket(DocumentationType.SWAGGER_2).apiInfo(swaggerInfo()).select()
 			.apis(RequestHandlerSelectors.basePackage("kr.or.dining_together.member.controller"))
-			.paths(PathSelectors.ant("/auth/**"))
+			.paths(PathSelectors.any())
 			.build()
 			.useDefaultResponseMessages(false); // 기본으로 세팅되는 200,401,403,404 메시지를 표시 하지 않음
 	}

--- a/member/src/main/java/kr/or/dining_together/member/controller/ExceptionController.java
+++ b/member/src/main/java/kr/or/dining_together/member/controller/ExceptionController.java
@@ -5,10 +5,13 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import kr.or.dining_together.member.advice.exception.AuthenticationEntryPointException;
 import kr.or.dining_together.member.model.CommonResult;
 import lombok.RequiredArgsConstructor;
 
+@Api(tags = {"2. Exception"})
 @RequiredArgsConstructor
 @RestController
 @RequestMapping(value = "/exception")
@@ -19,6 +22,7 @@ public class ExceptionController {
 		throw new AuthenticationEntryPointException();
 	}
 
+	@ApiOperation(value = "인가거부 에러", notes = "접근 불가능한 url에 접근시에 보내는 에러")
 	@GetMapping(value = "/accessdenied")
 	public CommonResult accessdeniedException() {
 		throw new AccessDeniedException("");

--- a/member/src/main/java/kr/or/dining_together/member/controller/SignController.java
+++ b/member/src/main/java/kr/or/dining_together/member/controller/SignController.java
@@ -36,7 +36,7 @@ public class SignController {
 	private final PasswordEncoder passwordEncoder;
 	private final UserService userService;
 	private final EmailService emailService;
-	
+
 	@ApiOperation(value = "로그인", notes = "이메일을 통해 로그인한다.")
 	@PostMapping(value = "/signin")
 	public SingleResult<String> userlogin(
@@ -51,9 +51,9 @@ public class SignController {
 	public CommonResult userSignUp(@RequestBody @ApiParam(value = "회원가입 정보", required = true) UserDto userDto) {
 		Long singUpResult = userService.save(userDto);
 		if (singUpResult == null) {
-			return responseService.getSuccessResult();
-		} else {
 			return responseService.getDefaultFailResult();
+		} else {
+			return responseService.getSuccessResult();
 		}
 	}
 

--- a/member/src/main/java/kr/or/dining_together/member/controller/SignController.java
+++ b/member/src/main/java/kr/or/dining_together/member/controller/SignController.java
@@ -1,9 +1,11 @@
 package kr.or.dining_together.member.controller;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.annotations.Api;
@@ -14,6 +16,7 @@ import kr.or.dining_together.member.dto.UserDto;
 import kr.or.dining_together.member.jpa.repo.UserRepository;
 import kr.or.dining_together.member.model.CommonResult;
 import kr.or.dining_together.member.model.SingleResult;
+import kr.or.dining_together.member.service.EmailService;
 import kr.or.dining_together.member.service.ResponseService;
 import kr.or.dining_together.member.service.UserService;
 import kr.or.dining_together.member.vo.LoginRequest;
@@ -32,7 +35,8 @@ public class SignController {
 	private final ResponseService responseService;
 	private final PasswordEncoder passwordEncoder;
 	private final UserService userService;
-
+	private final EmailService emailService;
+	
 	@ApiOperation(value = "로그인", notes = "이메일을 통해 로그인한다.")
 	@PostMapping(value = "/signin")
 	public SingleResult<String> userlogin(
@@ -45,8 +49,45 @@ public class SignController {
 	@ApiOperation(value = "회원가입", notes = "UserDto 객체를 입력 받아 회원가입 한다.")
 	@PostMapping(value = "/signup")
 	public CommonResult userSignUp(@RequestBody @ApiParam(value = "회원가입 정보", required = true) UserDto userDto) {
-		userService.save(userDto);
-		return responseService.getSuccessResult();
+		Long singUpResult = userService.save(userDto);
+		if (singUpResult == null) {
+			return responseService.getSuccessResult();
+		} else {
+			return responseService.getDefaultFailResult();
+		}
 	}
 
+	@ApiOperation(value = "이메일 중복확인", notes = "이메일 string을 입력받아 존재하는 email인지 확인한다.")
+	@GetMapping(value = "/signup")
+	public CommonResult userSignUpCheckEmail(
+		@RequestParam @ApiParam(value = "등록하려는 이메일", required = true) String email) {
+		if (userRepository.findByEmail(email) == null) {
+			return responseService.getSuccessResult();
+		} else {
+			return responseService.getDefaultFailResult();
+		}
+	}
+
+	@ApiOperation(value = "이메일 인증", notes = "이메일을 입력받아 키값을 전송한다.")
+	@PostMapping(value = "/signup/verification")
+	public CommonResult userSignUpSendCodeToEmail(
+		@RequestParam @ApiParam(value = "인증하려는 이메일", required = true) String email) {
+		if (emailService.sendAuthMail(email) == null) {
+			return responseService.getSuccessResult();
+		} else {
+			return responseService.getDefaultFailResult();
+		}
+	}
+
+	@ApiOperation(value = "이메일 키값 인증", notes = "이메일과 키값을 받아 맞는지 확인한다.")
+	@GetMapping(value = "/signup/verification")
+	public CommonResult userSignUpVerification(
+		@RequestParam @ApiParam(value = "이메일 정보", required = true) String email,
+		@RequestParam @ApiParam(value = "키값 정보", required = true) String key) {
+		if (emailService.checkEmailVerificationKey(email, key)) {
+			return responseService.getSuccessResult();
+		} else {
+			return responseService.getDefaultFailResult();
+		}
+	}
 }

--- a/member/src/main/java/kr/or/dining_together/member/dto/EmailInfoDto.java
+++ b/member/src/main/java/kr/or/dining_together/member/dto/EmailInfoDto.java
@@ -1,0 +1,21 @@
+package kr.or.dining_together.member.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@ApiModel(value = "EmailInfoDto", description = "이메일 인증정보 저장")
+public class EmailInfoDto {
+
+	@ApiModelProperty(value = "아이디(이메일)")
+	private String email;
+
+	@ApiModelProperty(value = "이름")
+	private String key;
+
+	@ApiModelProperty(value = "인증여부")
+	private Boolean used;
+}

--- a/member/src/main/java/kr/or/dining_together/member/dto/UserDto.java
+++ b/member/src/main/java/kr/or/dining_together/member/dto/UserDto.java
@@ -26,9 +26,6 @@ public class UserDto {
 	@ApiModelProperty(value = "비밀번호")
 	private String password;
 
-	@ApiModelProperty(value = "모바일 번호")
-	private String phoneNo;
-
 	@ApiModelProperty(value = "사용자 종류")
 	private UserType userType;
 

--- a/member/src/main/java/kr/or/dining_together/member/dto/UserDto.java
+++ b/member/src/main/java/kr/or/dining_together/member/dto/UserDto.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import kr.or.dining_together.member.jpa.entity.UserType;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -27,6 +28,9 @@ public class UserDto {
 
 	@ApiModelProperty(value = "모바일 번호")
 	private String phoneNo;
+
+	@ApiModelProperty(value = "사용자 종류")
+	private UserType userType;
 
 	@ApiModelProperty(value = "사용자 권한", required = false)
 	private List<String> roles = new ArrayList<>();

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/Customer.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/Customer.java
@@ -1,0 +1,19 @@
+package kr.or.dining_together.member.jpa.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+@Entity
+// @DiscriminatorValue("CUSTOMER")
+public class Customer extends User {
+
+	@Column(length = 100)
+	private String phoneNo;
+	@Column(length = 100)
+	private String dateOfBirth;
+	@Column(length = 100)
+	private String ageRange;
+	@Column(length = 100)
+	private String gender;
+
+}

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/EmailInfo.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/EmailInfo.java
@@ -1,0 +1,41 @@
+package kr.or.dining_together.member.jpa.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.validation.constraints.Email;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Table(name = "email")
+@ApiModel(description = "이메일 인증을 위한 도메인 객체")
+public class EmailInfo {
+	@Id // pk
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private long id;
+
+	@Email
+	@Column(nullable = false, unique = true, length = 100)
+	private String email;
+
+	@Column(length = 100)
+	@ApiModelProperty(notes = "이메일 인증키")
+	private String key;
+
+	@Column(nullable = false)
+	@ApiModelProperty(notes = "인증 여부")
+	private Boolean used;
+}

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/Store.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/Store.java
@@ -1,0 +1,15 @@
+package kr.or.dining_together.member.jpa.entity;
+
+import javax.persistence.Entity;
+
+@Entity
+// @DiscriminatorValue("STORE")
+public class Store extends User {
+
+	private String s_name;
+
+	private String description;
+	private String addr;
+	private String s_phone;
+
+}

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/User.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/User.java
@@ -9,6 +9,8 @@ import java.util.stream.Collectors;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -61,6 +63,10 @@ public class User implements UserDetails {
 
 	@Column(length = 100)
 	private String phoneNo;
+
+	@Enumerated(EnumType.STRING)
+	@ApiModelProperty(notes = "사용자 타입을 선택해 주세요")
+	private UserType type;
 
 	@Past
 	@ApiModelProperty(notes = "등록일을 입력해 주세요")

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/User.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/User.java
@@ -15,6 +15,8 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
 import javax.persistence.Table;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.Past;
@@ -42,6 +44,8 @@ import lombok.ToString;
 @ToString
 @Table(name = "user")
 @ApiModel(description = "사용자 상세 정보를 위한 도메인 객체")
+@Inheritance(strategy = InheritanceType.JOINED)
+// @DiscriminatorColumn(name="type")
 public class User implements UserDetails {
 	@Id // pk
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -61,8 +65,8 @@ public class User implements UserDetails {
 	@ApiModelProperty(notes = "사용자 이름을 입력해 주세요")
 	private String name;
 
-	@Column(length = 100)
-	private String phoneNo;
+	// @Column(length = 100)
+	// private String phoneNo;
 
 	@Enumerated(EnumType.STRING)
 	@ApiModelProperty(notes = "사용자 타입을 선택해 주세요")

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/UserType.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/UserType.java
@@ -1,0 +1,15 @@
+package kr.or.dining_together.member.jpa.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserType {
+	USER("USER", "일반사용자"),
+	SELLER("SELLER", "가게"),
+	ADMIN("ADMIN", "관리자");
+
+	private final String key;
+	private final String title;
+}

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/UserType.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/UserType.java
@@ -6,8 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum UserType {
-	USER("USER", "일반사용자"),
-	SELLER("SELLER", "가게"),
+	CUSTOMER("CUSTOMER", "일반사용자"),
+	STORE("STORE", "가게"),
 	ADMIN("ADMIN", "관리자");
 
 	private final String key;

--- a/member/src/main/java/kr/or/dining_together/member/jpa/repo/EmailInfoRepository.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/repo/EmailInfoRepository.java
@@ -1,0 +1,14 @@
+package kr.or.dining_together.member.jpa.repo;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.or.dining_together.member.jpa.entity.EmailInfo;
+
+public interface EmailInfoRepository extends JpaRepository<EmailInfo, Long> {
+
+	Optional<EmailInfo> findByEmail(String email);
+
+	Optional<EmailInfo> findByKey(String key);
+}

--- a/member/src/main/java/kr/or/dining_together/member/service/EmailService.java
+++ b/member/src/main/java/kr/or/dining_together/member/service/EmailService.java
@@ -1,0 +1,53 @@
+package kr.or.dining_together.member.service;
+
+import java.util.Random;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.or.dining_together.member.dto.EmailInfoDto;
+import kr.or.dining_together.member.jpa.entity.EmailInfo;
+import kr.or.dining_together.member.jpa.repo.EmailInfoRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+	private final JavaMailSender emailSender;
+	private final EmailInfoRepository emailInfoRepository;
+	private final ModelMapper modelMapper;
+
+	@Transactional
+	@Async
+	public Long sendAuthMail(String to) {
+		String key = makeRandomKey();
+		EmailInfoDto emailInfoDto = new EmailInfoDto();
+		emailInfoDto.setKey(key);
+		emailInfoDto.setEmail(to);
+		emailInfoDto.setUsed(false);
+
+		Long savedEmailId = emailInfoRepository.save(modelMapper.map(emailInfoDto, EmailInfo.class)).getId();
+
+		SimpleMailMessage message = new SimpleMailMessage();
+		message.setTo(to);
+		message.setSubject("[From 회식모아] 이메일 인증");
+		message.setText("인증번호는 " + key + " 입니다");
+		emailSender.send(message);
+
+		return savedEmailId;
+	}
+
+	public Boolean checkEmailVerificationKey(String email, String key) {
+		return (emailInfoRepository.findByKey(key).equals(emailInfoRepository.findByEmail(email)));
+	}
+
+	private String makeRandomKey() {
+		Random r = new Random();
+		return Integer.toString((r.nextInt(4589362) + 49311));
+	}
+}

--- a/member/src/main/java/kr/or/dining_together/member/service/ResponseService.java
+++ b/member/src/main/java/kr/or/dining_together/member/service/ResponseService.java
@@ -41,13 +41,27 @@ public class ResponseService {
 		result.setMsg(CommonResponse.SUCCESS.getMsg());
 	}
 
-	// 실패 결과만 처리
+	// 실패 코드와, msg받아 실패결과 처리
 	public CommonResult getFailResult(int code, String msg) {
 		CommonResult result = new CommonResult();
 		result.setSuccess(false);
 		result.setCode(code);
 		result.setMsg(msg);
 		return result;
+	}
+
+	// 실패 결과만 처리
+	public CommonResult getDefaultFailResult() {
+		CommonResult result = new CommonResult();
+		setFailResult(result);
+		return result;
+	}
+
+	// 실패하면 api 실패 데이터 세팅
+	private void setFailResult(CommonResult result) {
+		result.setSuccess(false);
+		result.setCode(CommonResponse.FAIL.getCode());
+		result.setMsg(CommonResponse.FAIL.getMsg());
 	}
 
 	public enum CommonResponse {

--- a/member/src/main/java/kr/or/dining_together/member/service/UserService.java
+++ b/member/src/main/java/kr/or/dining_together/member/service/UserService.java
@@ -31,7 +31,6 @@ public class UserService {
 			.email(userDto.getEmail())
 			.password(passwordEncoder.encode(userDto.getPassword()))
 			.name(userDto.getName())
-			.phoneNo(userDto.getPhoneNo())
 			.roles(userDto.getRoles())
 			.build()).getId();
 	}

--- a/member/src/main/resources/application.yml
+++ b/member/src/main/resources/application.yml
@@ -10,15 +10,16 @@ spring:
       settings:
         web-allow-others: true
       path: /h2-console
-    datasource:
-      driver-class-name: org.h2.Driver
-      url: jdbc:h2:mem:testdb
-    jpa:
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
       hibernate:
-        ddl-auto: create
-      properties:
-        hibernate:
-          format_sql: true
+        format_sql: true
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:dining
+    username: sa
   jwt:
     secret: secret_token
     expiration_time: 86400000
@@ -38,7 +39,9 @@ spring:
           connectiontimeout: 5000
           timeout: 5000
           writetimeout: 5000
-
+logging:
+  level:
+    org.hibernate.SQL: debug
 eureka:
   instance:
     instance-id: ${spring.application.name}:${spring.application.instance_id:${random.value}}

--- a/member/src/main/resources/application.yml
+++ b/member/src/main/resources/application.yml
@@ -19,12 +19,25 @@ spring:
       properties:
         hibernate:
           format_sql: true
-
   jwt:
     secret: secret_token
     expiration_time: 86400000
-
-
+  #mail 인증을 위한 정보.
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: moamoa202105@gmail.com
+    password: moa1234!
+    properties:
+      mail:
+        smtp:
+          starttls:
+            enable: true
+            required: true
+          auth: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
 
 eureka:
   instance:
@@ -33,7 +46,5 @@ eureka:
     register-with-eureka: true
     fetch-registry: true
     service-url:
-      defaultZone: http://127.0.0.1:8761/eureka
-
-
+      defaultZone: http://localhost:8761/eureka
 

--- a/member/src/test/java/kr/or/dining_together/member/controller/SignControllerTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/controller/SignControllerTest.java
@@ -26,6 +26,7 @@ import com.google.gson.Gson;
 
 import kr.or.dining_together.member.dto.UserDto;
 import kr.or.dining_together.member.jpa.entity.User;
+import kr.or.dining_together.member.jpa.entity.UserType;
 import kr.or.dining_together.member.jpa.repo.UserRepository;
 import kr.or.dining_together.member.vo.LoginRequest;
 
@@ -59,6 +60,7 @@ public class SignControllerTest {
 			.password(passwordEncoder.encode("test1111"))
 			.phoneNo("010-1234-5678")
 			.joinDate(new Date())
+			.type(UserType.USER)
 			.roles(Collections.singletonList("ROLE_USER"))
 			.build());
 
@@ -88,6 +90,7 @@ public class SignControllerTest {
 			.password("test2222")
 			.phoneNo("010-1234-1222")
 			.joinDate(new Date())
+			.type(UserType.USER)
 			.roles(Collections.singletonList("ROLE_USER"))
 			.build();
 		UserDto userDto = modelMapper.map(user, UserDto.class);

--- a/member/src/test/java/kr/or/dining_together/member/controller/SignControllerTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/controller/SignControllerTest.java
@@ -58,9 +58,8 @@ public class SignControllerTest {
 			.email("jifrozen@naver.com")
 			.name("문지언")
 			.password(passwordEncoder.encode("test1111"))
-			.phoneNo("010-1234-5678")
 			.joinDate(new Date())
-			.type(UserType.USER)
+			.type(UserType.CUSTOMER)
 			.roles(Collections.singletonList("ROLE_USER"))
 			.build());
 
@@ -71,7 +70,7 @@ public class SignControllerTest {
 		//given
 		String content = objectMapper.writeValueAsString(new LoginRequest("jifrozen@naver.com", "test1111"));
 		//when//then
-		mockMvc.perform(post("/auth/user")
+		mockMvc.perform(post("/member/auth/signin")
 			.content(content)
 			.contentType(MediaType.APPLICATION_JSON)
 			.accept(MediaType.APPLICATION_JSON))
@@ -88,9 +87,8 @@ public class SignControllerTest {
 			.email("jifrozen1@naver.com")
 			.name("문지언1")
 			.password("test2222")
-			.phoneNo("010-1234-1222")
 			.joinDate(new Date())
-			.type(UserType.USER)
+			.type(UserType.CUSTOMER)
 			.roles(Collections.singletonList("ROLE_USER"))
 			.build();
 		UserDto userDto = modelMapper.map(user, UserDto.class);
@@ -98,7 +96,7 @@ public class SignControllerTest {
 		String content = gson.toJson(userDto);
 
 		//when//then
-		mockMvc.perform(post("/auth/user/registeration")
+		mockMvc.perform(post("/member/auth/signup")
 			.content(content)
 			.contentType(MediaType.APPLICATION_JSON)
 			.accept(MediaType.APPLICATION_JSON))

--- a/member/src/test/java/kr/or/dining_together/member/jpa/repo/UserRepositoryTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/jpa/repo/UserRepositoryTest.java
@@ -36,9 +36,8 @@ public class UserRepositoryTest {
 			.email(email)
 			.name(name)
 			.password(passwordEncoder.encode("test1111"))
-			.phoneNo("010-1234-5678")
 			.joinDate(new Date())
-			.type(UserType.USER)
+			.type(UserType.CUSTOMER)
 			.roles(Collections.singletonList("ROLE_USER"))
 			.build());
 		//when

--- a/member/src/test/java/kr/or/dining_together/member/jpa/repo/UserRepositoryTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/jpa/repo/UserRepositoryTest.java
@@ -14,6 +14,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import kr.or.dining_together.member.jpa.entity.User;
+import kr.or.dining_together.member.jpa.entity.UserType;
 
 @RunWith(SpringRunner.class)
 @DataJpaTest
@@ -37,6 +38,7 @@ public class UserRepositoryTest {
 			.password(passwordEncoder.encode("test1111"))
 			.phoneNo("010-1234-5678")
 			.joinDate(new Date())
+			.type(UserType.USER)
 			.roles(Collections.singletonList("ROLE_USER"))
 			.build());
 		//when

--- a/member/src/test/java/kr/or/dining_together/member/service/UserServiceTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/service/UserServiceTest.java
@@ -38,9 +38,8 @@ public class UserServiceTest {
 			.email("qja9605@naver.com")
 			.name("신태범")
 			.password(passwordEncoder.encode("1234"))
-			.phoneNo("010-2691-3895")
 			.joinDate(new Date())
-			.type(UserType.USER)
+			.type(UserType.CUSTOMER)
 			.roles(roles)
 			.build();
 

--- a/member/src/test/java/kr/or/dining_together/member/service/UserServiceTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/service/UserServiceTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import kr.or.dining_together.member.dto.UserDto;
 import kr.or.dining_together.member.jpa.entity.User;
+import kr.or.dining_together.member.jpa.entity.UserType;
 import kr.or.dining_together.member.jpa.repo.UserRepository;
 import kr.or.dining_together.member.vo.LoginRequest;
 import lombok.extern.java.Log;
@@ -39,6 +40,7 @@ public class UserServiceTest {
 			.password(passwordEncoder.encode("1234"))
 			.phoneNo("010-2691-3895")
 			.joinDate(new Date())
+			.type(UserType.USER)
 			.roles(roles)
 			.build();
 


### PR DESCRIPTION
## 수정 사항
1. User 상속받는 Customer Store entity 생성
2. 그에 따른 회원가입 로직 수정
3. h2 연동 Bug 오타 수정

h2 정보
![image](https://user-images.githubusercontent.com/62784314/120485559-30e75880-c3ef-11eb-990a-1ea839c14f72.png)

회원가입 성공 후 테이블에 들어가 있는 모습
h2 연동으로 JPA 자동 테이블 생성된 모습
![image](https://user-images.githubusercontent.com/62784314/120485566-32b11c00-c3ef-11eb-9725-ca732dfbfbc1.png)


## 기타 사항
1. role과 type 같은 역할을 하기 때문에 한가지 삭제 부탁드립니다.
2. 소셜 로그인의 경우 제가 진행해도 괜찮을까요?
3. 아직 entity는 User entity 제외 미완성입니다.
4. 혹시 비밀번호 찾기를 할때도 이메일 인증이 필요한데 태범님이 회원가입 이메일인증을 바탕으로 진행 해주실 수 있을까요?

##참고문서
https://victorydntmd.tistory.com/209
https://stackoverflow.com/questions/51218227/user-class-for-spring-security-application