### PR TITLE
[Feat] Sign Up Email Verification

### DIFF
--- a/member/pom.xml
+++ b/member/pom.xml
@@ -64,12 +64,12 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.6.1</version>
+            <version>2.9.2</version>
         </dependency>
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>
-            <version>2.6.1</version>
+            <version>2.9.2</version>
         </dependency>
         <!-- h2 database -->
         <dependency>

--- a/member/pom.xml
+++ b/member/pom.xml
@@ -93,6 +93,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-mail</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/member/pom.xml
+++ b/member/pom.xml
@@ -33,23 +33,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.modelmapper</groupId>
-            <artifactId>modelmapper</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt</artifactId>
-            <version>0.9.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-security</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-test</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>
@@ -63,6 +46,21 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+        <!-- spring security & jwt token -->
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt</artifactId>
+            <version>0.9.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+        </dependency>
+        <!-- Swagger Api Documentation&UI -->
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
@@ -73,6 +71,7 @@
             <artifactId>springfox-swagger2</artifactId>
             <version>2.6.1</version>
         </dependency>
+        <!-- h2 database -->
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
@@ -83,20 +82,16 @@
             <artifactId>modelmapper</artifactId>
             <version>2.3.8</version>
         </dependency>
+        <!-- unit test library -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- send email -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
         </dependency>
     </dependencies>
     <dependencyManagement>

--- a/member/src/main/java/kr/or/dining_together/member/MemberApplication.java
+++ b/member/src/main/java/kr/or/dining_together/member/MemberApplication.java
@@ -1,12 +1,21 @@
 package kr.or.dining_together.member;
 
+import java.io.InputStream;
+
+import javax.mail.internet.MimeMessage;
+
 import org.modelmapper.ModelMapper;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.Bean;
+import org.springframework.mail.MailException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessagePreparator;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 @EnableDiscoveryClient
@@ -25,5 +34,56 @@ public class MemberApplication {
 	public ModelMapper modelMapper() {
 		ModelMapper modelMapper = new ModelMapper();
 		return modelMapper;
+	}
+
+	@Bean
+	public RestTemplate getRestTemplate(){
+		return new RestTemplate();
+	}
+
+	@Bean
+	public JavaMailSender javaMailSender() {
+		JavaMailSender javaMailSender=new JavaMailSender() {
+			@Override
+			public MimeMessage createMimeMessage() {
+				return null;
+			}
+
+			@Override
+			public MimeMessage createMimeMessage(InputStream inputStream) throws MailException {
+				return null;
+			}
+
+			@Override
+			public void send(MimeMessage mimeMessage) throws MailException {
+
+			}
+
+			@Override
+			public void send(MimeMessage... mimeMessages) throws MailException {
+
+			}
+
+			@Override
+			public void send(MimeMessagePreparator mimeMessagePreparator) throws MailException {
+
+			}
+
+			@Override
+			public void send(MimeMessagePreparator... mimeMessagePreparators) throws MailException {
+
+			}
+
+			@Override
+			public void send(SimpleMailMessage simpleMailMessage) throws MailException {
+
+			}
+
+			@Override
+			public void send(SimpleMailMessage... simpleMailMessages) throws MailException {
+
+			}
+		};
+		return javaMailSender;
 	}
 }

--- a/member/src/main/java/kr/or/dining_together/member/advice/ExceptionAdvice.java
+++ b/member/src/main/java/kr/or/dining_together/member/advice/ExceptionAdvice.java
@@ -8,8 +8,11 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import kr.or.dining_together.member.advice.exception.AuthenticationEntryPointException;
+import kr.or.dining_together.member.advice.exception.DataSaveFailedException;
 import kr.or.dining_together.member.advice.exception.LoginFailedException;
+import kr.or.dining_together.member.advice.exception.UserDuplicationException;
 import kr.or.dining_together.member.advice.exception.UserNotFoundException;
+import kr.or.dining_together.member.advice.exception.VerificationFailedException;
 import kr.or.dining_together.member.model.CommonResult;
 import kr.or.dining_together.member.service.ResponseService;
 import lombok.RequiredArgsConstructor;
@@ -23,26 +26,43 @@ public class ExceptionAdvice {
 	@ExceptionHandler(Exception.class)
 	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
 	protected CommonResult defaultException(HttpServletRequest request, Exception e) {
-		return responseService.getFailResult(500, "실패");
+		return responseService.getFailResult(HttpStatus.INTERNAL_SERVER_ERROR.value(), "실패");
 	}
 
 	@ExceptionHandler(UserNotFoundException.class)
 	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
 	protected CommonResult userNotFoundException(HttpServletRequest request, UserNotFoundException e) {
-		return responseService.getFailResult(501, "사용자가 존재하지 않습니다.");
+		return responseService.getFailResult(HttpStatus.INTERNAL_SERVER_ERROR.value(), "사용자가 존재하지 않습니다.");
 	}
 
 	@ExceptionHandler(LoginFailedException.class)
 	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
 	protected CommonResult loginFailedException(HttpServletRequest request, LoginFailedException e) {
-		return responseService.getFailResult(502, "로그인 실패했습니다..");
+		return responseService.getFailResult(HttpStatus.INTERNAL_SERVER_ERROR.value(), "로그인 실패했습니다.");
+	}
+
+	@ExceptionHandler(DataSaveFailedException.class)
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+	protected CommonResult userSaveFailedException(HttpServletRequest request, LoginFailedException e) {
+		return responseService.getFailResult(HttpStatus.INTERNAL_SERVER_ERROR.value(), "회원가입 정보저장에 실패했습니다..");
+	}
+
+	@ExceptionHandler(UserDuplicationException.class)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	protected CommonResult userDuplicationException(HttpServletRequest request, LoginFailedException e) {
+		return responseService.getFailResult(HttpStatus.BAD_REQUEST.value(), "이미 등록된 회원 이메일입니다.");
+	}
+
+	@ExceptionHandler(VerificationFailedException.class)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	protected CommonResult verificationFailedException(HttpServletRequest request, LoginFailedException e) {
+		return responseService.getFailResult(HttpStatus.BAD_REQUEST.value(), "이메일 인증키가 일치하지 않습니다");
 	}
 
 	@ExceptionHandler(AuthenticationEntryPointException.class)
 	@ResponseStatus(HttpStatus.UNAUTHORIZED)
 	public CommonResult authenticationEntryPointException(HttpServletRequest request,
 		AuthenticationEntryPointException e) {
-		return responseService.getFailResult(401, "권한이 없습니다");
+		return responseService.getFailResult(HttpStatus.UNAUTHORIZED.value(), "권한이 없습니다");
 	}
-
 }

--- a/member/src/main/java/kr/or/dining_together/member/advice/ExceptionAdvice.java
+++ b/member/src/main/java/kr/or/dining_together/member/advice/ExceptionAdvice.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import kr.or.dining_together.member.advice.exception.AuthenticationEntryPointException;
 import kr.or.dining_together.member.advice.exception.DataSaveFailedException;
+import kr.or.dining_together.member.advice.exception.CComunicationException;
 import kr.or.dining_together.member.advice.exception.LoginFailedException;
 import kr.or.dining_together.member.advice.exception.UserDuplicationException;
 import kr.or.dining_together.member.advice.exception.UserNotFoundException;
@@ -65,4 +66,12 @@ public class ExceptionAdvice {
 		AuthenticationEntryPointException e) {
 		return responseService.getFailResult(HttpStatus.UNAUTHORIZED.value(), "권한이 없습니다");
 	}
+
+
+	@ExceptionHandler(CComunicationException.class)
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+	protected CommonResult comunicationException(HttpServletRequest request, CComunicationException e) {
+		return responseService.getFailResult(502, "통신 중 오류가 발생했습니다.");
+	}
+
 }

--- a/member/src/main/java/kr/or/dining_together/member/advice/exception/CComunicationException.java
+++ b/member/src/main/java/kr/or/dining_together/member/advice/exception/CComunicationException.java
@@ -1,0 +1,15 @@
+package kr.or.dining_together.member.advice.exception;
+
+public class CComunicationException extends RuntimeException{
+	public CComunicationException() {
+		super();
+	}
+
+	public CComunicationException(String message) {
+		super(message);
+	}
+
+	public CComunicationException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/member/src/main/java/kr/or/dining_together/member/advice/exception/DataSaveFailedException.java
+++ b/member/src/main/java/kr/or/dining_together/member/advice/exception/DataSaveFailedException.java
@@ -1,0 +1,15 @@
+package kr.or.dining_together.member.advice.exception;
+
+public class DataSaveFailedException extends RuntimeException {
+	public DataSaveFailedException(String msg, Throwable t) {
+		super(msg, t);
+	}
+
+	public DataSaveFailedException(String msg) {
+		super(msg);
+	}
+
+	public DataSaveFailedException() {
+		super();
+	}
+}

--- a/member/src/main/java/kr/or/dining_together/member/advice/exception/UserDuplicationException.java
+++ b/member/src/main/java/kr/or/dining_together/member/advice/exception/UserDuplicationException.java
@@ -1,0 +1,15 @@
+package kr.or.dining_together.member.advice.exception;
+
+public class UserDuplicationException extends RuntimeException {
+	public UserDuplicationException(String msg, Throwable t) {
+		super(msg, t);
+	}
+
+	public UserDuplicationException(String msg) {
+		super(msg);
+	}
+
+	public UserDuplicationException() {
+		super();
+	}
+}

--- a/member/src/main/java/kr/or/dining_together/member/advice/exception/VerificationFailedException.java
+++ b/member/src/main/java/kr/or/dining_together/member/advice/exception/VerificationFailedException.java
@@ -1,0 +1,15 @@
+package kr.or.dining_together.member.advice.exception;
+
+public class VerificationFailedException extends RuntimeException {
+	public VerificationFailedException(String msg, Throwable t) {
+		super(msg, t);
+	}
+
+	public VerificationFailedException(String msg) {
+		super(msg);
+	}
+
+	public VerificationFailedException() {
+		super();
+	}
+}

--- a/member/src/main/java/kr/or/dining_together/member/config/SwaggerConfig.java
+++ b/member/src/main/java/kr/or/dining_together/member/config/SwaggerConfig.java
@@ -19,7 +19,7 @@ public class SwaggerConfig {
 	public Docket swaggerApi() {
 		return new Docket(DocumentationType.SWAGGER_2).apiInfo(swaggerInfo()).select()
 			.apis(RequestHandlerSelectors.basePackage("kr.or.dining_together.member.controller"))
-			.paths(PathSelectors.any())
+			.paths(PathSelectors.ant("/member/**"))
 			.build()
 			.useDefaultResponseMessages(false); // 기본으로 세팅되는 200,401,403,404 메시지를 표시 하지 않음
 	}

--- a/member/src/main/java/kr/or/dining_together/member/config/SwaggerConfig.java
+++ b/member/src/main/java/kr/or/dining_together/member/config/SwaggerConfig.java
@@ -19,7 +19,7 @@ public class SwaggerConfig {
 	public Docket swaggerApi() {
 		return new Docket(DocumentationType.SWAGGER_2).apiInfo(swaggerInfo()).select()
 			.apis(RequestHandlerSelectors.basePackage("kr.or.dining_together.member.controller"))
-			.paths(PathSelectors.ant("/auth/**"))
+			.paths(PathSelectors.any())
 			.build()
 			.useDefaultResponseMessages(false); // 기본으로 세팅되는 200,401,403,404 메시지를 표시 하지 않음
 	}

--- a/member/src/main/java/kr/or/dining_together/member/controller/ExceptionController.java
+++ b/member/src/main/java/kr/or/dining_together/member/controller/ExceptionController.java
@@ -5,10 +5,13 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import kr.or.dining_together.member.advice.exception.AuthenticationEntryPointException;
 import kr.or.dining_together.member.model.CommonResult;
 import lombok.RequiredArgsConstructor;
 
+@Api(tags = {"2. Exception"})
 @RequiredArgsConstructor
 @RestController
 @RequestMapping(value = "/exception")
@@ -19,6 +22,7 @@ public class ExceptionController {
 		throw new AuthenticationEntryPointException();
 	}
 
+	@ApiOperation(value = "인가거부 에러", notes = "접근 불가능한 url에 접근시에 보내는 에러")
 	@GetMapping(value = "/accessdenied")
 	public CommonResult accessdeniedException() {
 		throw new AccessDeniedException("");

--- a/member/src/main/java/kr/or/dining_together/member/controller/SignController.java
+++ b/member/src/main/java/kr/or/dining_together/member/controller/SignController.java
@@ -36,7 +36,7 @@ public class SignController {
 	private final PasswordEncoder passwordEncoder;
 	private final UserService userService;
 	private final EmailService emailService;
-	
+
 	@ApiOperation(value = "로그인", notes = "이메일을 통해 로그인한다.")
 	@PostMapping(value = "/signin")
 	public SingleResult<String> userlogin(
@@ -51,9 +51,9 @@ public class SignController {
 	public CommonResult userSignUp(@RequestBody @ApiParam(value = "회원가입 정보", required = true) UserDto userDto) {
 		Long singUpResult = userService.save(userDto);
 		if (singUpResult == null) {
-			return responseService.getSuccessResult();
-		} else {
 			return responseService.getDefaultFailResult();
+		} else {
+			return responseService.getSuccessResult();
 		}
 	}
 

--- a/member/src/main/java/kr/or/dining_together/member/controller/SignController.java
+++ b/member/src/main/java/kr/or/dining_together/member/controller/SignController.java
@@ -49,34 +49,24 @@ public class SignController {
 	@ApiOperation(value = "회원가입", notes = "UserDto 객체를 입력 받아 회원가입 한다.")
 	@PostMapping(value = "/signup")
 	public CommonResult userSignUp(@RequestBody @ApiParam(value = "회원가입 정보", required = true) UserDto userDto) {
-		Long singUpResult = userService.save(userDto);
-		if (singUpResult == null) {
-			return responseService.getDefaultFailResult();
-		} else {
-			return responseService.getSuccessResult();
-		}
+		userService.save(userDto);
+		return responseService.getSuccessResult();
 	}
 
 	@ApiOperation(value = "이메일 중복확인", notes = "이메일 string을 입력받아 존재하는 email인지 확인한다.")
 	@GetMapping(value = "/signup")
 	public CommonResult userSignUpCheckEmail(
 		@RequestParam @ApiParam(value = "등록하려는 이메일", required = true) String email) {
-		if (userRepository.findByEmail(email) == null) {
-			return responseService.getSuccessResult();
-		} else {
-			return responseService.getDefaultFailResult();
-		}
+		emailService.checkEmailExistence(email);
+		return responseService.getSuccessResult();
 	}
 
 	@ApiOperation(value = "이메일 인증", notes = "이메일을 입력받아 키값을 전송한다.")
 	@PostMapping(value = "/signup/verification")
 	public CommonResult userSignUpSendCodeToEmail(
 		@RequestParam @ApiParam(value = "인증하려는 이메일", required = true) String email) {
-		if (emailService.sendAuthMail(email) == null) {
-			return responseService.getSuccessResult();
-		} else {
-			return responseService.getDefaultFailResult();
-		}
+		emailService.sendAuthMail(email);
+		return responseService.getSuccessResult();
 	}
 
 	@ApiOperation(value = "이메일 키값 인증", notes = "이메일과 키값을 받아 맞는지 확인한다.")
@@ -84,10 +74,7 @@ public class SignController {
 	public CommonResult userSignUpVerification(
 		@RequestParam @ApiParam(value = "이메일 정보", required = true) String email,
 		@RequestParam @ApiParam(value = "키값 정보", required = true) String key) {
-		if (emailService.checkEmailVerificationKey(email, key)) {
-			return responseService.getSuccessResult();
-		} else {
-			return responseService.getDefaultFailResult();
-		}
+		emailService.checkEmailVerificationKey(email, key);
+		return responseService.getSuccessResult();
 	}
 }

--- a/member/src/main/java/kr/or/dining_together/member/controller/SignController.java
+++ b/member/src/main/java/kr/or/dining_together/member/controller/SignController.java
@@ -1,9 +1,11 @@
 package kr.or.dining_together.member.controller;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.annotations.Api;
@@ -14,6 +16,7 @@ import kr.or.dining_together.member.dto.UserDto;
 import kr.or.dining_together.member.jpa.repo.UserRepository;
 import kr.or.dining_together.member.model.CommonResult;
 import kr.or.dining_together.member.model.SingleResult;
+import kr.or.dining_together.member.service.EmailService;
 import kr.or.dining_together.member.service.ResponseService;
 import kr.or.dining_together.member.service.UserService;
 import kr.or.dining_together.member.vo.LoginRequest;
@@ -32,7 +35,8 @@ public class SignController {
 	private final ResponseService responseService;
 	private final PasswordEncoder passwordEncoder;
 	private final UserService userService;
-
+	private final EmailService emailService;
+	
 	@ApiOperation(value = "로그인", notes = "이메일을 통해 로그인한다.")
 	@PostMapping(value = "/signin")
 	public SingleResult<String> userlogin(
@@ -45,8 +49,45 @@ public class SignController {
 	@ApiOperation(value = "회원가입", notes = "UserDto 객체를 입력 받아 회원가입 한다.")
 	@PostMapping(value = "/signup")
 	public CommonResult userSignUp(@RequestBody @ApiParam(value = "회원가입 정보", required = true) UserDto userDto) {
-		userService.save(userDto);
-		return responseService.getSuccessResult();
+		Long singUpResult = userService.save(userDto);
+		if (singUpResult == null) {
+			return responseService.getSuccessResult();
+		} else {
+			return responseService.getDefaultFailResult();
+		}
 	}
 
+	@ApiOperation(value = "이메일 중복확인", notes = "이메일 string을 입력받아 존재하는 email인지 확인한다.")
+	@GetMapping(value = "/signup")
+	public CommonResult userSignUpCheckEmail(
+		@RequestParam @ApiParam(value = "등록하려는 이메일", required = true) String email) {
+		if (userRepository.findByEmail(email) == null) {
+			return responseService.getSuccessResult();
+		} else {
+			return responseService.getDefaultFailResult();
+		}
+	}
+
+	@ApiOperation(value = "이메일 인증", notes = "이메일을 입력받아 키값을 전송한다.")
+	@PostMapping(value = "/signup/verification")
+	public CommonResult userSignUpSendCodeToEmail(
+		@RequestParam @ApiParam(value = "인증하려는 이메일", required = true) String email) {
+		if (emailService.sendAuthMail(email) == null) {
+			return responseService.getSuccessResult();
+		} else {
+			return responseService.getDefaultFailResult();
+		}
+	}
+
+	@ApiOperation(value = "이메일 키값 인증", notes = "이메일과 키값을 받아 맞는지 확인한다.")
+	@GetMapping(value = "/signup/verification")
+	public CommonResult userSignUpVerification(
+		@RequestParam @ApiParam(value = "이메일 정보", required = true) String email,
+		@RequestParam @ApiParam(value = "키값 정보", required = true) String key) {
+		if (emailService.checkEmailVerificationKey(email, key)) {
+			return responseService.getSuccessResult();
+		} else {
+			return responseService.getDefaultFailResult();
+		}
+	}
 }

--- a/member/src/main/java/kr/or/dining_together/member/controller/SignController.java
+++ b/member/src/main/java/kr/or/dining_together/member/controller/SignController.java
@@ -1,24 +1,32 @@
 package kr.or.dining_together.member.controller;
 
+import java.util.Optional;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.sun.xml.bind.v2.runtime.unmarshaller.XsiNilLoader;
+
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import kr.or.dining_together.member.config.security.JwtTokenProvider;
 import kr.or.dining_together.member.dto.UserDto;
+import kr.or.dining_together.member.jpa.entity.User;
 import kr.or.dining_together.member.jpa.repo.UserRepository;
 import kr.or.dining_together.member.model.CommonResult;
 import kr.or.dining_together.member.model.SingleResult;
 import kr.or.dining_together.member.service.EmailService;
+import kr.or.dining_together.member.service.KakaoService;
 import kr.or.dining_together.member.service.ResponseService;
 import kr.or.dining_together.member.service.UserService;
+import kr.or.dining_together.member.vo.KakaoProfile;
 import kr.or.dining_together.member.vo.LoginRequest;
 import lombok.RequiredArgsConstructor;
 
@@ -30,7 +38,7 @@ public class SignController {
 	/*
 	로그인 회원가입 로직
 	 */
-	private final UserRepository userRepository;
+
 	private final JwtTokenProvider jwtTokenProvider;
 	private final ResponseService responseService;
 	private final PasswordEncoder passwordEncoder;
@@ -40,7 +48,7 @@ public class SignController {
 	@ApiOperation(value = "로그인", notes = "이메일을 통해 로그인한다.")
 	@PostMapping(value = "/signin")
 	public SingleResult<String> userlogin(
-		@RequestBody @ApiParam(value = "이메일 비밀번호", required = true) LoginRequest loginRequest) {
+		@RequestBody @ApiParam(value = "이메일 비밀번호", required = true) LoginRequest loginRequest) throws Throwable {
 		UserDto userDto = userService.login(loginRequest);
 		return responseService.getSingleResult(
 			jwtTokenProvider.createToken(String.valueOf(userDto.getEmail()), userDto.getRoles()));
@@ -76,5 +84,16 @@ public class SignController {
 		@RequestParam @ApiParam(value = "키값 정보", required = true) String key) {
 		emailService.checkEmailVerificationKey(email, key);
 		return responseService.getSuccessResult();
+	}
+
+	@ApiOperation(value="소셜 로그인", notes = " 소셜 회원 로그인을 한다.")
+	@PostMapping(value = "/signin/{provider}")
+	public SingleResult<String> signinByProvider(
+		@ApiParam(value = "서비스 제공자 provider", required = true,defaultValue = "kakao") @PathVariable String provider,
+		@ApiParam(value = "소셜 access token",required = true) @RequestParam String accessToken) {
+
+		User signedUser = userService.signupByKakao(accessToken,provider);
+		return responseService.getSingleResult(jwtTokenProvider.createToken(String.valueOf(signedUser.getEmail()), signedUser.getRoles()));
+
 	}
 }

--- a/member/src/main/java/kr/or/dining_together/member/controller/SocialController.java
+++ b/member/src/main/java/kr/or/dining_together/member/controller/SocialController.java
@@ -1,0 +1,69 @@
+package kr.or.dining_together.member.controller;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.servlet.ModelAndView;
+
+import com.google.gson.Gson;
+
+import kr.or.dining_together.member.service.KakaoService;
+import lombok.RequiredArgsConstructor;
+
+/**
+* @package : kr.or.dining_together.member.controller
+* @name: SocialController.java
+* @date : 2021/06/03 1:24 오전
+* @author : jifrozen
+* @version : 1.0.0
+* @description : 소셜 로그인을 위해 요청
+* @modified :
+**/
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("member/auth/")
+public class SocialController {
+
+	private final Environment env;
+	private final RestTemplate restTemplate;
+	private final Gson gson;
+	private final KakaoService kakaoService;
+
+
+	@Value("${spring.url.base}")
+	private String baseUrl;
+	@Value("${spring.social.kakao.client_id}")
+	private String kakaoClientId;
+	@Value("${spring.social.kakao.redirect}")
+	private String kakaoRedirect;
+
+
+	@GetMapping
+	public ModelAndView socialLogin(ModelAndView mav){
+		StringBuilder loginUrl=new StringBuilder()
+			.append(env.getProperty("spring.social.kakao.url.login"))
+			.append("?client_id=").append(kakaoClientId)
+			.append("&response_type=code")
+			.append("&redirect_uri=").append(baseUrl).append(kakaoRedirect);
+
+		mav.addObject("loginUrl",loginUrl);
+		mav.setViewName("social/login");
+		return mav;
+	}
+
+	@GetMapping(value = "/kakao")
+	public ModelAndView redirectKakao(ModelAndView mav, @RequestParam String code){
+		mav.addObject("authInfo",kakaoService.getKakaoTokenInfo(code));
+		mav.setViewName("social/redirectKakao");
+		return mav;
+	}
+
+
+
+
+
+}

--- a/member/src/main/java/kr/or/dining_together/member/dto/EmailInfoDto.java
+++ b/member/src/main/java/kr/or/dining_together/member/dto/EmailInfoDto.java
@@ -1,0 +1,21 @@
+package kr.or.dining_together.member.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@ApiModel(value = "EmailInfoDto", description = "이메일 인증정보 저장")
+public class EmailInfoDto {
+
+	@ApiModelProperty(value = "아이디(이메일)")
+	private String email;
+
+	@ApiModelProperty(value = "이름")
+	private String key;
+
+	@ApiModelProperty(value = "인증여부")
+	private Boolean used;
+}

--- a/member/src/main/java/kr/or/dining_together/member/dto/EmailInfoDto.java
+++ b/member/src/main/java/kr/or/dining_together/member/dto/EmailInfoDto.java
@@ -10,6 +10,9 @@ import lombok.NoArgsConstructor;
 @ApiModel(value = "EmailInfoDto", description = "이메일 인증정보 저장")
 public class EmailInfoDto {
 
+	@ApiModelProperty(value = "이메일 pk")
+	private long id;
+
 	@ApiModelProperty(value = "아이디(이메일)")
 	private String email;
 

--- a/member/src/main/java/kr/or/dining_together/member/dto/UserDto.java
+++ b/member/src/main/java/kr/or/dining_together/member/dto/UserDto.java
@@ -26,9 +26,6 @@ public class UserDto {
 	@ApiModelProperty(value = "비밀번호")
 	private String password;
 
-	@ApiModelProperty(value = "모바일 번호")
-	private String phoneNo;
-
 	@ApiModelProperty(value = "사용자 종류")
 	private UserType userType;
 

--- a/member/src/main/java/kr/or/dining_together/member/dto/UserDto.java
+++ b/member/src/main/java/kr/or/dining_together/member/dto/UserDto.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import kr.or.dining_together.member.jpa.entity.UserType;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -27,6 +28,9 @@ public class UserDto {
 
 	@ApiModelProperty(value = "모바일 번호")
 	private String phoneNo;
+
+	@ApiModelProperty(value = "사용자 종류")
+	private UserType userType;
 
 	@ApiModelProperty(value = "사용자 권한", required = false)
 	private List<String> roles = new ArrayList<>();

--- a/member/src/main/java/kr/or/dining_together/member/dto/UserDto.java
+++ b/member/src/main/java/kr/or/dining_together/member/dto/UserDto.java
@@ -1,17 +1,21 @@
 package kr.or.dining_together.member.dto;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import kr.or.dining_together.member.jpa.entity.UserType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
+@AllArgsConstructor
 @ApiModel(value = "UserDto", description = "사용자")
+@Builder
 public class UserDto {
 
 	@ApiModelProperty(value = "사용자 pk")
@@ -26,8 +30,8 @@ public class UserDto {
 	@ApiModelProperty(value = "비밀번호")
 	private String password;
 
-	@ApiModelProperty(value = "사용자 종류")
-	private UserType userType;
+	@ApiModelProperty(notes = "사용자 등록일")
+	private Date joinDate;
 
 	@ApiModelProperty(value = "사용자 권한", required = false)
 	private List<String> roles = new ArrayList<>();

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/Customer.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/Customer.java
@@ -1,0 +1,19 @@
+package kr.or.dining_together.member.jpa.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+@Entity
+// @DiscriminatorValue("CUSTOMER")
+public class Customer extends User {
+
+	@Column(length = 100)
+	private String phoneNo;
+	@Column(length = 100)
+	private String dateOfBirth;
+	@Column(length = 100)
+	private String ageRange;
+	@Column(length = 100)
+	private String gender;
+
+}

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/Customer.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/Customer.java
@@ -3,7 +3,11 @@ package kr.or.dining_together.member.jpa.entity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+
 @Entity
+@RequiredArgsConstructor
 // @DiscriminatorValue("CUSTOMER")
 public class Customer extends User {
 

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/EmailInfo.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/EmailInfo.java
@@ -1,0 +1,41 @@
+package kr.or.dining_together.member.jpa.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.validation.constraints.Email;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Table(name = "email")
+@ApiModel(description = "이메일 인증을 위한 도메인 객체")
+public class EmailInfo {
+	@Id // pk
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private long id;
+
+	@Email
+	@Column(nullable = false, unique = true, length = 100)
+	private String email;
+
+	@Column(length = 100)
+	@ApiModelProperty(notes = "이메일 인증키")
+	private String key;
+
+	@Column(nullable = false)
+	@ApiModelProperty(notes = "인증 여부")
+	private Boolean used;
+}

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/EmailInfo.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/EmailInfo.java
@@ -11,19 +11,21 @@ import javax.validation.constraints.Email;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+@Builder
 @Entity
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
-@Table(name = "email")
+@Table(name = "emailinfo")
 @ApiModel(description = "이메일 인증을 위한 도메인 객체")
 public class EmailInfo {
-	@Id // pk
+	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private long id;
 
@@ -35,7 +37,6 @@ public class EmailInfo {
 	@ApiModelProperty(notes = "이메일 인증키")
 	private String key;
 
-	@Column(nullable = false)
 	@ApiModelProperty(notes = "인증 여부")
 	private Boolean used;
 }

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/Store.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/Store.java
@@ -1,0 +1,15 @@
+package kr.or.dining_together.member.jpa.entity;
+
+import javax.persistence.Entity;
+
+@Entity
+// @DiscriminatorValue("STORE")
+public class Store extends User {
+
+	private String s_name;
+
+	private String description;
+	private String addr;
+	private String s_phone;
+
+}

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/User.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/User.java
@@ -9,14 +9,14 @@ import java.util.stream.Collectors;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
 import javax.persistence.Table;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.Past;
@@ -47,7 +47,7 @@ import lombok.ToString;
 @Inheritance(strategy = InheritanceType.JOINED)
 // @DiscriminatorColumn(name="type")
 public class User implements UserDetails {
-	@Id // pk
+	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private long id;
 
@@ -68,21 +68,35 @@ public class User implements UserDetails {
 	// @Column(length = 100)
 	// private String phoneNo;
 
-	@Enumerated(EnumType.STRING)
-	@ApiModelProperty(notes = "사용자 타입을 선택해 주세요")
-	private UserType type;
-
 	@Past
-	@ApiModelProperty(notes = "등록일을 입력해 주세요")
+	@ApiModelProperty(notes = "등록일 정보입니다. 자동으로 입력됩니다.")
 	private Date joinDate;
 
 	@ElementCollection(fetch = FetchType.EAGER)
 	@Builder.Default
 	private List<String> roles = new ArrayList<>();
 
+	@Column(name = "createdDate")
+	@ApiModelProperty(notes = "테이블의 생성일 정보입니다. 자동으로 입력됩니다.")
+	public Date createdDate;
+
+	@Column(name = "updatedDate")
+	@ApiModelProperty(notes = "테이블의 수정일 정보입니다. 자동으로 입력됩니다.")
+	public Date updatedDate;
+
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {
 		return this.roles.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+	}
+
+	@PrePersist
+	void joinDate() {
+		this.joinDate = this.createdDate = this.updatedDate = new Date();
+	}
+
+	@PreUpdate
+	void updateDate() {
+		this.updatedDate = new Date();
 	}
 
 	//  json 출력 안함

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/User.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/User.java
@@ -9,6 +9,8 @@ import java.util.stream.Collectors;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -61,6 +63,10 @@ public class User implements UserDetails {
 
 	@Column(length = 100)
 	private String phoneNo;
+
+	@Enumerated(EnumType.STRING)
+	@ApiModelProperty(notes = "사용자 타입을 선택해 주세요")
+	private UserType type;
 
 	@Past
 	@ApiModelProperty(notes = "등록일을 입력해 주세요")

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/User.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/User.java
@@ -72,6 +72,9 @@ public class User implements UserDetails {
 	@ApiModelProperty(notes = "등록일 정보입니다. 자동으로 입력됩니다.")
 	private Date joinDate;
 
+	@Column(length=100)
+	private String provider;
+
 	@ElementCollection(fetch = FetchType.EAGER)
 	@Builder.Default
 	private List<String> roles = new ArrayList<>();

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/User.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/User.java
@@ -15,6 +15,8 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
 import javax.persistence.Table;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.Past;
@@ -42,6 +44,8 @@ import lombok.ToString;
 @ToString
 @Table(name = "user")
 @ApiModel(description = "사용자 상세 정보를 위한 도메인 객체")
+@Inheritance(strategy = InheritanceType.JOINED)
+// @DiscriminatorColumn(name="type")
 public class User implements UserDetails {
 	@Id // pk
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -61,8 +65,8 @@ public class User implements UserDetails {
 	@ApiModelProperty(notes = "사용자 이름을 입력해 주세요")
 	private String name;
 
-	@Column(length = 100)
-	private String phoneNo;
+	// @Column(length = 100)
+	// private String phoneNo;
 
 	@Enumerated(EnumType.STRING)
 	@ApiModelProperty(notes = "사용자 타입을 선택해 주세요")

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/UserType.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/UserType.java
@@ -1,0 +1,15 @@
+package kr.or.dining_together.member.jpa.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserType {
+	USER("USER", "일반사용자"),
+	SELLER("SELLER", "가게"),
+	ADMIN("ADMIN", "관리자");
+
+	private final String key;
+	private final String title;
+}

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/UserType.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/UserType.java
@@ -6,8 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum UserType {
-	USER("USER", "일반사용자"),
-	SELLER("SELLER", "가게"),
+	CUSTOMER("CUSTOMER", "일반사용자"),
+	STORE("STORE", "가게"),
 	ADMIN("ADMIN", "관리자");
 
 	private final String key;

--- a/member/src/main/java/kr/or/dining_together/member/jpa/repo/CustomerRepository.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/repo/CustomerRepository.java
@@ -1,0 +1,9 @@
+package kr.or.dining_together.member.jpa.repo;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.or.dining_together.member.jpa.entity.Customer;
+
+public interface CustomerRepository extends JpaRepository<Customer,Long> {
+
+}

--- a/member/src/main/java/kr/or/dining_together/member/jpa/repo/EmailInfoRepository.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/repo/EmailInfoRepository.java
@@ -1,0 +1,14 @@
+package kr.or.dining_together.member.jpa.repo;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.or.dining_together.member.jpa.entity.EmailInfo;
+
+public interface EmailInfoRepository extends JpaRepository<EmailInfo, Long> {
+
+	Optional<EmailInfo> findByEmail(String email);
+
+	Optional<EmailInfo> findByKey(String key);
+}

--- a/member/src/main/java/kr/or/dining_together/member/jpa/repo/UserRepository.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/repo/UserRepository.java
@@ -6,9 +6,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import kr.or.dining_together.member.jpa.entity.User;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository<T extends User> extends JpaRepository<T, Long> {
 	@Override
-	Optional<User> findById(Long id);
+	Optional<T> findById(Long id);
 
-	Optional<User> findByEmail(String email);
+	Optional<T> findByEmail(String email);
+
+	Optional<T> findByEmailAndProvider(String email, String provider);
 }

--- a/member/src/main/java/kr/or/dining_together/member/service/CustomUserDetailService.java
+++ b/member/src/main/java/kr/or/dining_together/member/service/CustomUserDetailService.java
@@ -6,8 +6,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import kr.or.dining_together.member.advice.exception.UserNotFoundException;
+import kr.or.dining_together.member.jpa.entity.User;
 import kr.or.dining_together.member.jpa.repo.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 
 @Service
 @RequiredArgsConstructor
@@ -15,9 +17,17 @@ public class CustomUserDetailService implements UserDetailsService {
 
 	private final UserRepository userRepository;
 
+
 	@Override
 	@Transactional(readOnly = true)
 	public UserDetails loadUserByUsername(String email) {
-		return userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
+		//오류 있어서 수정햇는데 잘되는지 확인 필요
+		User user = null;
+		try {
+			user= (User)userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
+		} catch (Throwable throwable) {
+			throwable.printStackTrace();
+		}
+		return user;
 	}
 }

--- a/member/src/main/java/kr/or/dining_together/member/service/EmailService.java
+++ b/member/src/main/java/kr/or/dining_together/member/service/EmailService.java
@@ -1,0 +1,53 @@
+package kr.or.dining_together.member.service;
+
+import java.util.Random;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.or.dining_together.member.dto.EmailInfoDto;
+import kr.or.dining_together.member.jpa.entity.EmailInfo;
+import kr.or.dining_together.member.jpa.repo.EmailInfoRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+	private final JavaMailSender emailSender;
+	private final EmailInfoRepository emailInfoRepository;
+	private final ModelMapper modelMapper;
+
+	@Transactional
+	@Async
+	public Long sendAuthMail(String to) {
+		String key = makeRandomKey();
+		EmailInfoDto emailInfoDto = new EmailInfoDto();
+		emailInfoDto.setKey(key);
+		emailInfoDto.setEmail(to);
+		emailInfoDto.setUsed(false);
+
+		Long savedEmailId = emailInfoRepository.save(modelMapper.map(emailInfoDto, EmailInfo.class)).getId();
+
+		SimpleMailMessage message = new SimpleMailMessage();
+		message.setTo(to);
+		message.setSubject("[From 회식모아] 이메일 인증");
+		message.setText("인증번호는 " + key + " 입니다");
+		emailSender.send(message);
+
+		return savedEmailId;
+	}
+
+	public Boolean checkEmailVerificationKey(String email, String key) {
+		return (emailInfoRepository.findByKey(key).equals(emailInfoRepository.findByEmail(email)));
+	}
+
+	private String makeRandomKey() {
+		Random r = new Random();
+		return Integer.toString((r.nextInt(4589362) + 49311));
+	}
+}

--- a/member/src/main/java/kr/or/dining_together/member/service/EmailService.java
+++ b/member/src/main/java/kr/or/dining_together/member/service/EmailService.java
@@ -5,6 +5,7 @@ import java.util.Random;
 
 import org.modelmapper.ModelMapper;
 import org.springframework.mail.SimpleMailMessage;
+
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -26,7 +27,6 @@ public class EmailService {
 	private final JavaMailSender emailSender;
 	private final EmailInfoRepository emailInfoRepository;
 	private final UserRepository userRepository;
-	private final ModelMapper modelMapper;
 
 	@Transactional
 	@Async

--- a/member/src/main/java/kr/or/dining_together/member/service/KakaoService.java
+++ b/member/src/main/java/kr/or/dining_together/member/service/KakaoService.java
@@ -1,0 +1,84 @@
+package kr.or.dining_together.member.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonParser;
+
+import kr.or.dining_together.member.vo.KakaoProfile;
+import kr.or.dining_together.member.vo.RetKakaoAuth;
+import kr.or.dining_together.member.advice.exception.CComunicationException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+
+	private final RestTemplate restTemplate;
+	private final Environment env;
+	private final Gson gson;
+
+	@Value("${spring.url.base}")
+	private String baseUrl;
+
+	@Value("${spring.social.kakao.client_id}")
+	private String kakaoClientId;
+
+	@Value("${spring.social.kakao.redirect}")
+	private String kakaoRedirect;
+
+	/**
+	 * 카카오 플랫폼에서 사용자 정보를 요청한다.
+	 **/
+	public KakaoProfile getKakaoProfile(String accessToken){
+		// Set header : Content-type: application/x-www-form-urlencoded
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+		headers.set("Authorization", "Bearer " + accessToken);
+
+		// Set http entity
+		HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(null, headers);
+		try {
+			// Request profile
+			ResponseEntity<String> response = restTemplate.postForEntity(env.getProperty("spring.social.kakao.url.profile"), request, String.class);
+			if (response.getStatusCode() == HttpStatus.OK)
+				return gson.fromJson(response.getBody(), KakaoProfile.class);
+		} catch (Exception e) {
+			throw new CComunicationException();
+		}
+		throw new CComunicationException();
+	}
+
+	/**
+	 * 카카오 플랫폼에서 사용자 토큰을 발급받는다.
+	 **/
+	public RetKakaoAuth getKakaoTokenInfo(String code) {
+		// Set header : Content-type: application/x-www-form-urlencoded
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+		// Set parameter
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("grant_type", "authorization_code");
+		params.add("client_id", kakaoClientId);
+		params.add("redirect_uri", baseUrl + kakaoRedirect);
+		params.add("code", code);
+		// Set http entity
+		HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+		ResponseEntity<String> response = restTemplate.postForEntity(env.getProperty("spring.social.kakao.url.token"), request, String.class);
+		if (response.getStatusCode() == HttpStatus.OK) {
+			return gson.fromJson(response.getBody(), RetKakaoAuth.class);
+		}
+		return null;
+	}
+	
+}

--- a/member/src/main/java/kr/or/dining_together/member/service/ResponseService.java
+++ b/member/src/main/java/kr/or/dining_together/member/service/ResponseService.java
@@ -41,13 +41,27 @@ public class ResponseService {
 		result.setMsg(CommonResponse.SUCCESS.getMsg());
 	}
 
-	// 실패 결과만 처리
+	// 실패 코드와, msg받아 실패결과 처리
 	public CommonResult getFailResult(int code, String msg) {
 		CommonResult result = new CommonResult();
 		result.setSuccess(false);
 		result.setCode(code);
 		result.setMsg(msg);
 		return result;
+	}
+
+	// 실패 결과만 처리
+	public CommonResult getDefaultFailResult() {
+		CommonResult result = new CommonResult();
+		setFailResult(result);
+		return result;
+	}
+
+	// 실패하면 api 실패 데이터 세팅
+	private void setFailResult(CommonResult result) {
+		result.setSuccess(false);
+		result.setCode(CommonResponse.FAIL.getCode());
+		result.setMsg(CommonResponse.FAIL.getMsg());
 	}
 
 	public enum CommonResponse {

--- a/member/src/main/java/kr/or/dining_together/member/service/UserService.java
+++ b/member/src/main/java/kr/or/dining_together/member/service/UserService.java
@@ -31,7 +31,6 @@ public class UserService {
 			.email(userDto.getEmail())
 			.password(passwordEncoder.encode(userDto.getPassword()))
 			.name(userDto.getName())
-			.phoneNo(userDto.getPhoneNo())
 			.roles(userDto.getRoles())
 			.build()).getId();
 	}

--- a/member/src/main/java/kr/or/dining_together/member/service/UserService.java
+++ b/member/src/main/java/kr/or/dining_together/member/service/UserService.java
@@ -4,6 +4,7 @@ import org.modelmapper.ModelMapper;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import kr.or.dining_together.member.advice.exception.DataSaveFailedException;
 import kr.or.dining_together.member.advice.exception.LoginFailedException;
 import kr.or.dining_together.member.dto.UserDto;
 import kr.or.dining_together.member.jpa.entity.User;
@@ -21,18 +22,23 @@ public class UserService {
 
 	public UserDto login(LoginRequest loginRequest) {
 		User user = userRepository.findByEmail(loginRequest.getEmail()).orElseThrow(LoginFailedException::new);
-		if (!passwordEncoder.matches(loginRequest.getPassword(), user.getPassword()))
+		if (!passwordEncoder.matches(loginRequest.getPassword(), user.getPassword())) {
 			throw new LoginFailedException();
+		}
 		return modelMapper.map(user, UserDto.class);
 	}
 
-	public Long save(UserDto userDto) {
-		return userRepository.save(User.builder()
+	public void save(UserDto userDto) {
+		Long saveResult = userRepository.save(User.builder()
 			.email(userDto.getEmail())
 			.password(passwordEncoder.encode(userDto.getPassword()))
 			.name(userDto.getName())
 			.roles(userDto.getRoles())
 			.build()).getId();
+		if (saveResult == null) {
+			throw new DataSaveFailedException();
+		}
+		return;
 	}
 
 }

--- a/member/src/main/java/kr/or/dining_together/member/service/UserService.java
+++ b/member/src/main/java/kr/or/dining_together/member/service/UserService.java
@@ -1,5 +1,8 @@
 package kr.or.dining_together.member.service;
 
+import java.util.Collections;
+import java.util.Optional;
+
 import org.modelmapper.ModelMapper;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -7,8 +10,12 @@ import org.springframework.stereotype.Service;
 import kr.or.dining_together.member.advice.exception.DataSaveFailedException;
 import kr.or.dining_together.member.advice.exception.LoginFailedException;
 import kr.or.dining_together.member.dto.UserDto;
+import kr.or.dining_together.member.jpa.entity.Customer;
 import kr.or.dining_together.member.jpa.entity.User;
+import kr.or.dining_together.member.jpa.repo.CustomerRepository;
 import kr.or.dining_together.member.jpa.repo.UserRepository;
+import kr.or.dining_together.member.vo.KakaoProfile;
+import kr.or.dining_together.member.vo.KakaoProfile.Kakao_properties;
 import kr.or.dining_together.member.vo.LoginRequest;
 import lombok.RequiredArgsConstructor;
 
@@ -19,9 +26,11 @@ public class UserService {
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
 	private final ModelMapper modelMapper;
+	private final KakaoService kakaoService;
+	private final CustomerRepository customerRepository;
 
-	public UserDto login(LoginRequest loginRequest) {
-		User user = userRepository.findByEmail(loginRequest.getEmail()).orElseThrow(LoginFailedException::new);
+	public UserDto login(LoginRequest loginRequest) throws Throwable {
+		User user = (User)userRepository.findByEmail(loginRequest.getEmail()).orElseThrow(LoginFailedException::new);
 		if (!passwordEncoder.matches(loginRequest.getPassword(), user.getPassword())) {
 			throw new LoginFailedException();
 		}
@@ -29,16 +38,40 @@ public class UserService {
 	}
 
 	public void save(UserDto userDto) {
-		Long saveResult = userRepository.save(User.builder()
+		User user=User.builder()
 			.email(userDto.getEmail())
 			.password(passwordEncoder.encode(userDto.getPassword()))
 			.name(userDto.getName())
 			.roles(userDto.getRoles())
-			.build()).getId();
+			.build();
+
+		userRepository.save(user);
+
+		Long saveResult = user.getId();
 		if (saveResult == null) {
 			throw new DataSaveFailedException();
 		}
 		return;
+	}
+
+	public User signupByKakao(String accessToken, String provider){
+		KakaoProfile profile=kakaoService.getKakaoProfile(accessToken);
+		KakaoProfile.Kakao_account kakaoAccount = profile.getKakao_account();
+		Optional<User> user=userRepository.findByEmailAndProvider(String.valueOf(kakaoAccount.getEmail()),provider);
+		if(user.isPresent()){
+			return user.get();
+		}else{
+			User kakaoUser=User.builder()
+				.email(String.valueOf(kakaoAccount.getEmail()))
+				.name(kakaoAccount.getEmail())
+				.provider(provider)
+				.roles(Collections.singletonList("ROLE_USER"))
+				.build();
+
+			userRepository.save(kakaoUser);
+			return kakaoUser;
+
+		}
 	}
 
 }

--- a/member/src/main/java/kr/or/dining_together/member/vo/KakaoProfile.java
+++ b/member/src/main/java/kr/or/dining_together/member/vo/KakaoProfile.java
@@ -1,0 +1,36 @@
+package kr.or.dining_together.member.vo;
+
+import java.util.Properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class KakaoProfile {
+	private Long id;
+	private Kakao_properties kakao_properties;
+	private Kakao_account kakao_account;
+
+
+	@Getter
+	@Setter
+	@ToString
+	public static class Kakao_properties {
+		private String nickname;
+		private String thumbnail_image;
+		private String profile_image;
+	}
+
+	@Getter
+	@Setter
+	@ToString
+	public static class Kakao_account {
+		private String email;
+		private String birthday;
+		private String age_range;
+		private String gender;
+	}
+}

--- a/member/src/main/java/kr/or/dining_together/member/vo/RetKakaoAuth.java
+++ b/member/src/main/java/kr/or/dining_together/member/vo/RetKakaoAuth.java
@@ -1,0 +1,24 @@
+package kr.or.dining_together.member.vo;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+* @package : kr.or.dining_together.member.vo
+* @name: RetKakaoAuth.java
+* @date : 2021/06/03 1:30 오전
+* @author : jifrozen
+* @version : 1.0.0
+* @description : 카카오 token api 연동시 맵핑을 위한 모델 생성
+* @modified :
+**/
+
+@Getter
+@Setter
+public class RetKakaoAuth {
+	private String access_token;
+	private String token_type;
+	private String refresh_token;
+	private long expires_in;
+	private String scope;
+}

--- a/member/src/main/resources/application.yml
+++ b/member/src/main/resources/application.yml
@@ -10,15 +10,16 @@ spring:
       settings:
         web-allow-others: true
       path: /h2-console
-    datasource:
-      driver-class-name: org.h2.Driver
-      url: jdbc:h2:mem:testdb
-    jpa:
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
       hibernate:
-        ddl-auto: create
-      properties:
-        hibernate:
-          format_sql: true
+        format_sql: true
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:dining
+    username: sa
   jwt:
     secret: secret_token
     expiration_time: 86400000
@@ -38,7 +39,9 @@ spring:
           connectiontimeout: 5000
           timeout: 5000
           writetimeout: 5000
-
+logging:
+  level:
+    org.hibernate.SQL: debug
 eureka:
   instance:
     instance-id: ${spring.application.name}:${spring.application.instance_id:${random.value}}

--- a/member/src/main/resources/application.yml
+++ b/member/src/main/resources/application.yml
@@ -19,12 +19,25 @@ spring:
       properties:
         hibernate:
           format_sql: true
-
   jwt:
     secret: secret_token
     expiration_time: 86400000
-
-
+  #mail 인증을 위한 정보.
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: moamoa202105@gmail.com
+    password: moa1234!
+    properties:
+      mail:
+        smtp:
+          starttls:
+            enable: true
+            required: true
+          auth: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
 
 eureka:
   instance:
@@ -33,7 +46,5 @@ eureka:
     register-with-eureka: true
     fetch-registry: true
     service-url:
-      defaultZone: http://127.0.0.1:8761/eureka
-
-
+      defaultZone: http://localhost:8761/eureka
 

--- a/member/src/main/resources/application.yml
+++ b/member/src/main/resources/application.yml
@@ -23,6 +23,17 @@ spring:
   jwt:
     secret: secret_token
     expiration_time: 86400000
+  social:
+    kakao:
+      client_id: cce7add11392983e7402a4bb7ad6fd07
+      redirect: /member/social/login/kakao
+      url:
+        login: https://kauth.kakao.com/oauth/authorize
+        token: https://kauth.kakao.com/oauth/token
+        profile: https://kapi.kakao.com/v2/user/me
+  url:
+    base: http://localhost:8000
+
 #mail 인증을 위한 정보.
 mail:
   host: smtp.gmail.com
@@ -39,9 +50,14 @@ mail:
         connectiontimeout: 5000
         timeout: 5000
         writetimeout: 5000
+
+
 logging:
   level:
     org.hibernate.SQL: debug
+
+
+
 eureka:
   instance:
     instance-id: ${spring.application.name}:${spring.application.instance_id:${random.value}}

--- a/member/src/main/resources/application.yml
+++ b/member/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
       enabled: true
       settings:
         web-allow-others: true
-      path: /h2-console
+      path: /member/h2-console
   jpa:
     hibernate:
       ddl-auto: create
@@ -23,22 +23,22 @@ spring:
   jwt:
     secret: secret_token
     expiration_time: 86400000
-  #mail 인증을 위한 정보.
-  mail:
-    host: smtp.gmail.com
-    port: 587
-    username: moamoa202105@gmail.com
-    password: moa1234!
-    properties:
-      mail:
-        smtp:
-          starttls:
-            enable: true
-            required: true
-          auth: true
-          connectiontimeout: 5000
-          timeout: 5000
-          writetimeout: 5000
+#mail 인증을 위한 정보.
+mail:
+  host: smtp.gmail.com
+  port: 587
+  username: moamoa202105@gmail.com
+  password: moa1234!
+  properties:
+    mail:
+      smtp:
+        starttls:
+          enable: true
+          required: true
+        auth: true
+        connectiontimeout: 5000
+        timeout: 5000
+        writetimeout: 5000
 logging:
   level:
     org.hibernate.SQL: debug

--- a/member/src/test/java/kr/or/dining_together/member/controller/SignControllerTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/controller/SignControllerTest.java
@@ -26,7 +26,6 @@ import com.google.gson.Gson;
 
 import kr.or.dining_together.member.dto.UserDto;
 import kr.or.dining_together.member.jpa.entity.User;
-import kr.or.dining_together.member.jpa.entity.UserType;
 import kr.or.dining_together.member.jpa.repo.UserRepository;
 import kr.or.dining_together.member.vo.LoginRequest;
 
@@ -36,7 +35,6 @@ import kr.or.dining_together.member.vo.LoginRequest;
 @Transactional
 public class SignControllerTest {
 
-	@Autowired
 	private MockMvc mockMvc;
 
 	@Autowired
@@ -45,7 +43,6 @@ public class SignControllerTest {
 	@Autowired
 	private PasswordEncoder passwordEncoder;
 
-	@Autowired
 	private ObjectMapper objectMapper;
 
 	@Autowired
@@ -59,7 +56,6 @@ public class SignControllerTest {
 			.name("문지언")
 			.password(passwordEncoder.encode("test1111"))
 			.joinDate(new Date())
-			.type(UserType.CUSTOMER)
 			.roles(Collections.singletonList("ROLE_USER"))
 			.build());
 
@@ -88,7 +84,6 @@ public class SignControllerTest {
 			.name("문지언1")
 			.password("test2222")
 			.joinDate(new Date())
-			.type(UserType.CUSTOMER)
 			.roles(Collections.singletonList("ROLE_USER"))
 			.build();
 		UserDto userDto = modelMapper.map(user, UserDto.class);

--- a/member/src/test/java/kr/or/dining_together/member/controller/SignControllerTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/controller/SignControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
+import com.netflix.discovery.converters.Auto;
 
 import kr.or.dining_together.member.dto.UserDto;
 import kr.or.dining_together.member.jpa.entity.User;
@@ -35,6 +36,7 @@ import kr.or.dining_together.member.vo.LoginRequest;
 @Transactional
 public class SignControllerTest {
 
+	@Autowired
 	private MockMvc mockMvc;
 
 	@Autowired
@@ -43,6 +45,7 @@ public class SignControllerTest {
 	@Autowired
 	private PasswordEncoder passwordEncoder;
 
+	@Autowired
 	private ObjectMapper objectMapper;
 
 	@Autowired
@@ -83,7 +86,6 @@ public class SignControllerTest {
 			.email("jifrozen1@naver.com")
 			.name("문지언1")
 			.password("test2222")
-			.joinDate(new Date())
 			.roles(Collections.singletonList("ROLE_USER"))
 			.build();
 		UserDto userDto = modelMapper.map(user, UserDto.class);

--- a/member/src/test/java/kr/or/dining_together/member/controller/SignControllerTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/controller/SignControllerTest.java
@@ -26,6 +26,7 @@ import com.google.gson.Gson;
 
 import kr.or.dining_together.member.dto.UserDto;
 import kr.or.dining_together.member.jpa.entity.User;
+import kr.or.dining_together.member.jpa.entity.UserType;
 import kr.or.dining_together.member.jpa.repo.UserRepository;
 import kr.or.dining_together.member.vo.LoginRequest;
 
@@ -59,6 +60,7 @@ public class SignControllerTest {
 			.password(passwordEncoder.encode("test1111"))
 			.phoneNo("010-1234-5678")
 			.joinDate(new Date())
+			.type(UserType.USER)
 			.roles(Collections.singletonList("ROLE_USER"))
 			.build());
 
@@ -88,6 +90,7 @@ public class SignControllerTest {
 			.password("test2222")
 			.phoneNo("010-1234-1222")
 			.joinDate(new Date())
+			.type(UserType.USER)
 			.roles(Collections.singletonList("ROLE_USER"))
 			.build();
 		UserDto userDto = modelMapper.map(user, UserDto.class);

--- a/member/src/test/java/kr/or/dining_together/member/controller/SignControllerTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/controller/SignControllerTest.java
@@ -58,9 +58,8 @@ public class SignControllerTest {
 			.email("jifrozen@naver.com")
 			.name("문지언")
 			.password(passwordEncoder.encode("test1111"))
-			.phoneNo("010-1234-5678")
 			.joinDate(new Date())
-			.type(UserType.USER)
+			.type(UserType.CUSTOMER)
 			.roles(Collections.singletonList("ROLE_USER"))
 			.build());
 
@@ -71,7 +70,7 @@ public class SignControllerTest {
 		//given
 		String content = objectMapper.writeValueAsString(new LoginRequest("jifrozen@naver.com", "test1111"));
 		//when//then
-		mockMvc.perform(post("/auth/user")
+		mockMvc.perform(post("/member/auth/signin")
 			.content(content)
 			.contentType(MediaType.APPLICATION_JSON)
 			.accept(MediaType.APPLICATION_JSON))
@@ -88,9 +87,8 @@ public class SignControllerTest {
 			.email("jifrozen1@naver.com")
 			.name("문지언1")
 			.password("test2222")
-			.phoneNo("010-1234-1222")
 			.joinDate(new Date())
-			.type(UserType.USER)
+			.type(UserType.CUSTOMER)
 			.roles(Collections.singletonList("ROLE_USER"))
 			.build();
 		UserDto userDto = modelMapper.map(user, UserDto.class);
@@ -98,7 +96,7 @@ public class SignControllerTest {
 		String content = gson.toJson(userDto);
 
 		//when//then
-		mockMvc.perform(post("/auth/user/registeration")
+		mockMvc.perform(post("/member/auth/signup")
 			.content(content)
 			.contentType(MediaType.APPLICATION_JSON)
 			.accept(MediaType.APPLICATION_JSON))

--- a/member/src/test/java/kr/or/dining_together/member/jpa/repo/EmailInfoRepositoryTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/jpa/repo/EmailInfoRepositoryTest.java
@@ -1,0 +1,44 @@
+package kr.or.dining_together.member.jpa.repo;
+
+import static org.junit.Assert.*;
+
+import java.util.Optional;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import kr.or.dining_together.member.jpa.entity.EmailInfo;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+public class EmailInfoRepositoryTest {
+
+	@Autowired
+	private EmailInfoRepository emailInfoRepository;
+
+	@Autowired
+	private ModelMapper modelMapper;
+
+	@Test
+	public void findByEmail() {
+		String email = "qja9605@naver.com";
+		String key = "1234";
+		EmailInfo emailInfo = EmailInfo.builder()
+			.key(key)
+			.email(email)
+			.used(false)
+			.build();
+
+		System.out.println(emailInfo);
+		emailInfoRepository.save(emailInfo);
+		Optional<EmailInfo> emailInfo1 = emailInfoRepository.findByEmail(email);
+
+		assertNotNull(emailInfo1);
+		assertTrue(emailInfo1.isPresent());
+		assertEquals(emailInfo1.get().getEmail(), email);
+	}
+}

--- a/member/src/test/java/kr/or/dining_together/member/jpa/repo/UserRepositoryTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/jpa/repo/UserRepositoryTest.java
@@ -36,9 +36,8 @@ public class UserRepositoryTest {
 			.email(email)
 			.name(name)
 			.password(passwordEncoder.encode("test1111"))
-			.phoneNo("010-1234-5678")
 			.joinDate(new Date())
-			.type(UserType.USER)
+			.type(UserType.CUSTOMER)
 			.roles(Collections.singletonList("ROLE_USER"))
 			.build());
 		//when

--- a/member/src/test/java/kr/or/dining_together/member/jpa/repo/UserRepositoryTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/jpa/repo/UserRepositoryTest.java
@@ -14,6 +14,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import kr.or.dining_together.member.jpa.entity.User;
+import kr.or.dining_together.member.jpa.entity.UserType;
 
 @RunWith(SpringRunner.class)
 @DataJpaTest
@@ -37,6 +38,7 @@ public class UserRepositoryTest {
 			.password(passwordEncoder.encode("test1111"))
 			.phoneNo("010-1234-5678")
 			.joinDate(new Date())
+			.type(UserType.USER)
 			.roles(Collections.singletonList("ROLE_USER"))
 			.build());
 		//when

--- a/member/src/test/java/kr/or/dining_together/member/jpa/repo/UserRepositoryTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/jpa/repo/UserRepositoryTest.java
@@ -8,13 +8,14 @@ import java.util.Optional;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import kr.or.dining_together.member.dto.UserDto;
 import kr.or.dining_together.member.jpa.entity.User;
-import kr.or.dining_together.member.jpa.entity.UserType;
 
 @RunWith(SpringRunner.class)
 @DataJpaTest
@@ -25,6 +26,9 @@ public class UserRepositoryTest {
 
 	@Autowired
 	private PasswordEncoder passwordEncoder;
+
+	@Autowired
+	private ModelMapper modelMapper;
 
 	@Test
 	public void findByEmail() {
@@ -37,11 +41,15 @@ public class UserRepositoryTest {
 			.name(name)
 			.password(passwordEncoder.encode("test1111"))
 			.joinDate(new Date())
-			.type(UserType.CUSTOMER)
 			.roles(Collections.singletonList("ROLE_USER"))
 			.build());
+
 		//when
 		Optional<User> user = userRepository.findByEmail(email);
+		System.out.println(user.get());
+		System.out.println(modelMapper.map(user.get(), UserDto.class));
+		System.out.println(modelMapper.map(modelMapper.map(user.get(), UserDto.class), User.class));
+
 		//then
 		assertNotNull(user);
 		assertTrue(user.isPresent());

--- a/member/src/test/java/kr/or/dining_together/member/service/EmailServiceTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/service/EmailServiceTest.java
@@ -1,0 +1,46 @@
+package kr.or.dining_together.member.service;
+
+import java.util.Optional;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.or.dining_together.member.jpa.entity.EmailInfo;
+import kr.or.dining_together.member.jpa.repo.EmailInfoRepository;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@Transactional
+public class EmailServiceTest {
+
+	@Autowired
+	EmailInfoRepository emailInfoRepository;
+
+	JavaMailSender javaMailSender;
+
+	@Autowired
+	EmailService emailService;
+
+	@Test
+	public void mailSendAndCheckTest() {
+		//given
+		String email = "qja9605@naver.com";
+		String notTypedEmail = "qja9605@gmail.com";
+
+		//when
+		emailService.sendAuthMail(email);
+		Optional<EmailInfo> emailInfo = emailInfoRepository.findByEmail(email);
+		String key = emailInfo.get().getKey();
+		Optional<EmailInfo> emailInfo1 = emailInfoRepository.findByKey(key);
+		Optional<EmailInfo> emailInfo2 = emailInfoRepository.findByEmail(notTypedEmail);
+
+		//then
+		emailService.checkEmailExistence(notTypedEmail);
+		emailService.checkEmailVerificationKey(email, key);
+	}
+}

--- a/member/src/test/java/kr/or/dining_together/member/service/UserServiceTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/service/UserServiceTest.java
@@ -38,9 +38,8 @@ public class UserServiceTest {
 			.email("qja9605@naver.com")
 			.name("신태범")
 			.password(passwordEncoder.encode("1234"))
-			.phoneNo("010-2691-3895")
 			.joinDate(new Date())
-			.type(UserType.USER)
+			.type(UserType.CUSTOMER)
 			.roles(roles)
 			.build();
 

--- a/member/src/test/java/kr/or/dining_together/member/service/UserServiceTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/service/UserServiceTest.java
@@ -3,6 +3,7 @@ package kr.or.dining_together.member.service;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -13,9 +14,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import kr.or.dining_together.member.dto.UserDto;
 import kr.or.dining_together.member.jpa.entity.User;
-import kr.or.dining_together.member.jpa.entity.UserType;
 import kr.or.dining_together.member.jpa.repo.UserRepository;
-import kr.or.dining_together.member.vo.LoginRequest;
 import lombok.extern.java.Log;
 
 @RunWith(SpringRunner.class)
@@ -30,29 +29,24 @@ public class UserServiceTest {
 	private PasswordEncoder passwordEncoder;
 
 	@Test
-	public void insertTest() {
+	public void signUpTest() {
 		//given
 		List<String> roles = Arrays.asList("USER");
-		User user = User.builder()
+		UserDto userDto = UserDto.builder()
 			.id(1L)
 			.email("qja9605@naver.com")
 			.name("신태범")
 			.password(passwordEncoder.encode("1234"))
 			.joinDate(new Date())
-			.type(UserType.CUSTOMER)
 			.roles(roles)
 			.build();
 
 		//when
-		userRepository.save(user);
+		userService.save(userDto);
+		Optional<User> user = userRepository.findByEmail("qja9605@naver.com");
 
-		LoginRequest loginRequest = new LoginRequest("qja9605@naver.com", "1234");
-
-		UserDto userDto = userService.login(loginRequest);
 		//then
-
 		System.out.println(user);
-		System.out.println(userDto);
 	}
 
 }

--- a/member/src/test/java/kr/or/dining_together/member/service/UserServiceTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/service/UserServiceTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import kr.or.dining_together.member.dto.UserDto;
 import kr.or.dining_together.member.jpa.entity.User;
+import kr.or.dining_together.member.jpa.entity.UserType;
 import kr.or.dining_together.member.jpa.repo.UserRepository;
 import kr.or.dining_together.member.vo.LoginRequest;
 import lombok.extern.java.Log;
@@ -39,6 +40,7 @@ public class UserServiceTest {
 			.password(passwordEncoder.encode("1234"))
 			.phoneNo("010-2691-3895")
 			.joinDate(new Date())
+			.type(UserType.USER)
 			.roles(roles)
 			.build();
 


### PR DESCRIPTION
이전 PR과 이어지므로 간단히 작성하겠습니다.

## 수정사항
1.  ExceptionAdvice.java 에서 숫자로 적어두었던 코드롤 httpStatus.value()로 통일하였습니다. 
이 과정에서 status code는 ResponseStatus 어노테이션을 기준으로 변경하였습니다.

2. 코멘트 달아주신 것 처럼, 기존 Controller에서 처리했던 것을 Service Layer에서 ExceptionHandler를 사용하여 처리하는 것으로 변경하였습니다.

3. EmailRepsitory와 EmailService에 대한 TestCode 작성하였습니다.

4. @PrePersist 어노테이션으로 joinDate 정보가 테이블에 저장될때 자동생성되도록 변경하였습니다 (기존에는 정보를 입력해야 했습니다.)

5. User Entity에 데이터 수정/생성일자 데이터를 추가하여 entity 작성하였습니다.  실제 사용되는 서비스의 DB의 경우 이 정보가 저장되어 있는 경우가 많아 일단 작성해두었습니다. 이에 대한 코멘트 달아주시면 감사하겠습니다. 

## 이외 코멘트
1. swagger에 /member/*로 설정할 경우 exception api에 대한 정보는 드러나지 않는데 any()로 하지 않는 이유가 있을까요?

2. redis 설정의 경우 토의후에 클라우드 구성환경 협의가 이루어지면 이에 맞춰서 제가 클라우드 구성하고, redis 설정도 함께 진행하겠습니다.

3. modelmapper보다 mapstruct가 더 최신버전이고 조작이 간편해보이는데, 이를 도입하는건 어떨까요?
- https://meetup.toast.com/posts/213
- 현재 modelmapper의 경우 dto -> entity 변환시 column이 일치하지 않아 제대로 동작하지 않는 이슈도 있습니다.

4. elastic search 공부중인데, 찾아보니 spring data elastic search를 이용하여 api를 구성할 수 있을 것 같습니다. 
- 데이터 구축 : 회원가입과 경매등록시에 검색 data에도 등록하는 로직을 추가해야 합니다.(아마 프론트에서 회원가입/경매등록이 성공적으로 처리되면 추가하는 식으로 하면될 것 같습니다.)

- 추가로 공유가 필요한 정보가 있을 경우 또 알려드리도록 하겠습니다.

감사합니다

