### PR TITLE
[Fix] Signup

### DIFF
--- a/member/src/main/java/kr/or/dining_together/member/controller/SignController.java
+++ b/member/src/main/java/kr/or/dining_together/member/controller/SignController.java
@@ -92,11 +92,9 @@ public class SignController {
 		switch (provider) {
 			case "naver":
 				signedUser = userService.signupByNaver(accessToken, provider);
-				;
 				break;
 			case "kakao":
 				signedUser = userService.signupByKakao(accessToken, provider);
-				;
 				break;
 		}
 		return responseService.getSingleResult(

--- a/member/src/main/java/kr/or/dining_together/member/controller/SignController.java
+++ b/member/src/main/java/kr/or/dining_together/member/controller/SignController.java
@@ -48,7 +48,7 @@ public class SignController {
 			jwtTokenProvider.createToken(String.valueOf(userDto.getEmail()), userDto.getRoles()));
 	}
 
-	@ApiOperation(value = "회원가입", notes = "UserDto 객체를 입력 받아 회원가입 한다.")
+	@ApiOperation(value = "회원가입", notes = "CustomerSignUpRequest 객체를 입력 받아 회원가입 한다.")
 	@PostMapping(value = "/signup")
 	public CommonResult userSignUp(
 		@RequestBody @ApiParam(value = "회원가입 정보", required = true) SignUpRequest signUpRequest) {
@@ -97,6 +97,7 @@ public class SignController {
 				signedUser = userService.signupByKakao(accessToken, provider);
 				break;
 		}
+
 		return responseService.getSingleResult(
 			jwtTokenProvider.createToken(String.valueOf(signedUser.getEmail()), signedUser.getRoles()));
 

--- a/member/src/main/java/kr/or/dining_together/member/controller/SocialController.java
+++ b/member/src/main/java/kr/or/dining_together/member/controller/SocialController.java
@@ -75,8 +75,7 @@ public class SocialController {
 
 		mav.addObject("naverLoginUrl", naverLoginUrl);
 
-
-		mav.setViewName("/member/social/login");
+		mav.setViewName("member/social/login");
 
 		return mav;
 	}
@@ -84,14 +83,14 @@ public class SocialController {
 	@GetMapping(value = "/kakao")
 	public ModelAndView redirectKakao(ModelAndView mav, @RequestParam String code) {
 		mav.addObject("authInfo", kakaoService.getKakaoTokenInfo(code));
-		mav.setViewName("social/redirectKakao");
+		mav.setViewName("member/social/redirectKakao");
 		return mav;
 	}
 
 	@GetMapping(value = "/naver")
 	public ModelAndView redirectNaver(ModelAndView mav, @RequestParam String code, @RequestParam String state) {
 		mav.addObject("authInfo", naverService.getNaverTokenInfo(code, state));
-		mav.setViewName("social/redirectNaver");
+		mav.setViewName("member/social/redirectNaver");
 		return mav;
 	}
 

--- a/member/src/main/java/kr/or/dining_together/member/dto/SignUserDto.java
+++ b/member/src/main/java/kr/or/dining_together/member/dto/SignUserDto.java
@@ -1,0 +1,25 @@
+package kr.or.dining_together.member.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(value = "SignUserDto", description = "회원가입사용자")
+@Builder
+public class SignUserDto {
+	@ApiModelProperty(value = "아이디(이메일)")
+	private String email;
+
+	@ApiModelProperty(value = "이름")
+	private String name;
+
+	@ApiModelProperty(value = "비밀번호")
+	private String password;
+
+}

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/Store.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/Store.java
@@ -1,5 +1,6 @@
 package kr.or.dining_together.member.jpa.entity;
 
+import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.PrimaryKeyJoinColumn;
@@ -17,5 +18,6 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 public class Store extends User {
 	@ApiModelProperty(notes = "서류 제출 확인여부를 나타낸다")
+	@Column(columnDefinition = "boolean default false")
 	private Boolean documentChecked;
 }

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/User.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/User.java
@@ -77,7 +77,7 @@ public class User implements UserDetails {
 	@ApiModelProperty(notes = "등록일 정보입니다. 자동으로 입력됩니다.")
 	private Date joinDate;
 
-	@Column(length = 100)
+	@Column(length = 100, columnDefinition = "varchar(100) default 'application'")
 	private String provider;
 
 	@ElementCollection(fetch = FetchType.EAGER)

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/User.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/User.java
@@ -137,4 +137,5 @@ public class User implements UserDetails {
 	public boolean isEnabled() {
 		return true;
 	}
+
 }

--- a/member/src/main/java/kr/or/dining_together/member/service/EmailService.java
+++ b/member/src/main/java/kr/or/dining_together/member/service/EmailService.java
@@ -22,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class EmailService {
 
+	private static final String FROM_ADDRESS = "moamoa202105@gmail.com";
 	private final JavaMailSender emailSender;
 	private final EmailInfoRepository emailInfoRepository;
 	private final UserRepository userRepository;

--- a/member/src/main/java/kr/or/dining_together/member/service/EmailService.java
+++ b/member/src/main/java/kr/or/dining_together/member/service/EmailService.java
@@ -25,7 +25,6 @@ public class EmailService {
 	private final JavaMailSender emailSender;
 	private final EmailInfoRepository emailInfoRepository;
 	private final UserRepository userRepository;
-	private static final String FROM_ADDRESS = "moamoa202105@gmail.com";
 
 	@Transactional
 	@Async
@@ -41,7 +40,6 @@ public class EmailService {
 
 		SimpleMailMessage message = new SimpleMailMessage();
 		message.setTo(to);
-		message.setFrom(EmailService.FROM_ADDRESS);
 		message.setSubject("[From 회식모아] 이메일 인증");
 		message.setText("인증번호는 " + key + " 입니다");
 		emailSender.send(message);

--- a/member/src/main/java/kr/or/dining_together/member/service/UserService.java
+++ b/member/src/main/java/kr/or/dining_together/member/service/UserService.java
@@ -17,6 +17,7 @@ import kr.or.dining_together.member.jpa.entity.Store;
 import kr.or.dining_together.member.jpa.entity.User;
 import kr.or.dining_together.member.jpa.entity.UserType;
 import kr.or.dining_together.member.jpa.repo.CustomerRepository;
+import kr.or.dining_together.member.jpa.repo.StoreRepository;
 import kr.or.dining_together.member.jpa.repo.UserRepository;
 import kr.or.dining_together.member.vo.KakaoProfile;
 import kr.or.dining_together.member.vo.LoginRequest;
@@ -34,6 +35,7 @@ public class UserService {
 	private final KakaoService kakaoService;
 	private final NaverService naverService;
 	private final CustomerRepository customerRepository;
+	private final StoreRepository storeRepository;
 
 	public UserDto login(LoginRequest loginRequest) throws Throwable {
 		User user = (User)userRepository.findByEmail(loginRequest.getEmail()).orElseThrow(LoginFailedException::new);
@@ -68,10 +70,9 @@ public class UserService {
 				.build());
 		}
 
-		if (userRepository.findByEmail(userDto.getEmail()).isEmpty()) {
+		if (userRepository.findByEmail(signUpRequest.getSignUserDto().getEmail()).isEmpty()) {
 			throw new DataSaveFailedException();
 		}
-		return;
 	}
 
 	public User signupByKakao(String accessToken, String provider) {

--- a/member/src/main/java/kr/or/dining_together/member/service/UserService.java
+++ b/member/src/main/java/kr/or/dining_together/member/service/UserService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import kr.or.dining_together.member.advice.exception.DataSaveFailedException;
 import kr.or.dining_together.member.advice.exception.LoginFailedException;
+import kr.or.dining_together.member.dto.SignUserDto;
 import kr.or.dining_together.member.dto.UserDto;
 import kr.or.dining_together.member.jpa.entity.Customer;
 import kr.or.dining_together.member.jpa.entity.Store;
@@ -19,8 +20,8 @@ import kr.or.dining_together.member.jpa.repo.CustomerRepository;
 import kr.or.dining_together.member.jpa.repo.UserRepository;
 import kr.or.dining_together.member.vo.KakaoProfile;
 import kr.or.dining_together.member.vo.LoginRequest;
-import kr.or.dining_together.member.vo.SignUpRequest;
 import kr.or.dining_together.member.vo.NaverProfile;
+import kr.or.dining_together.member.vo.SignUpRequest;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -45,25 +46,25 @@ public class UserService {
 	@SuppressWarnings("checkstyle:RegexpSingleline")
 	@Transactional
 	public void save(SignUpRequest signUpRequest) {
-		String userType = signUpRequest.getUserType().getValue();
-		UserDto userDto = signUpRequest.getUserDto();
+		UserType userType = signUpRequest.getUserType();
+		SignUserDto userDto = signUpRequest.getSignUserDto();
 
-		if (userType == UserType.CUSTOMER.getValue()) {
+		if (userType == UserType.CUSTOMER) {
 			userRepository.save(Customer.builder()
 				.email(userDto.getEmail())
 				.password(passwordEncoder.encode(userDto.getPassword()))
 				.name(userDto.getName())
-				.roles(userDto.getRoles())
 				.gender(signUpRequest.getGender())
 				.age(signUpRequest.getAge())
+				.provider("application")
 				.build());
-		} else if (userType == UserType.STORE.getValue()) {
+		} else if (userType == UserType.STORE) {
 			userRepository.save(Store.builder()
 				.email(userDto.getEmail())
 				.password(passwordEncoder.encode(userDto.getPassword()))
 				.name(userDto.getName())
-				.roles(userDto.getRoles())
 				.documentChecked(false)
+				.provider("application")
 				.build());
 		}
 
@@ -81,7 +82,7 @@ public class UserService {
 		if (user.isPresent()) {
 			return user.get();
 		} else {
-			User kakaoUser = User.builder()
+			Customer kakaoUser = Customer.builder()
 				.email(String.valueOf(kakaoAccount.getEmail()))
 				.name(kakaoAccount.getEmail())
 				.provider(provider)
@@ -100,7 +101,7 @@ public class UserService {
 		if (user.isPresent()) {
 			return user.get();
 		} else {
-			User naverUser = User.builder()
+			Customer naverUser = Customer.builder()
 				.email(naverAccount.getEmail())
 				.name(naverAccount.getName())
 				.provider(provider)

--- a/member/src/main/java/kr/or/dining_together/member/vo/SignUpRequest.java
+++ b/member/src/main/java/kr/or/dining_together/member/vo/SignUpRequest.java
@@ -20,4 +20,5 @@ public class SignUpRequest {
 	private UserType userType;
 	private int age;
 	private String gender;
+
 }

--- a/member/src/main/java/kr/or/dining_together/member/vo/SignUpRequest.java
+++ b/member/src/main/java/kr/or/dining_together/member/vo/SignUpRequest.java
@@ -1,6 +1,6 @@
 package kr.or.dining_together.member.vo;
 
-import kr.or.dining_together.member.dto.UserDto;
+import kr.or.dining_together.member.dto.SignUserDto;
 import kr.or.dining_together.member.jpa.entity.UserType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,7 +16,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @Builder
 public class SignUpRequest {
-	private UserDto userDto;
+	private SignUserDto signUserDto;
 	private UserType userType;
 	private int age;
 	private String gender;

--- a/member/src/main/resources/application.yml
+++ b/member/src/main/resources/application.yml
@@ -43,7 +43,7 @@ spring:
     level:
       org.hibernate.SQL: debug
   url:
-    base: http://localhost:8000
+    base: https://localhost:8000
   social:
     kakao:
       client_id: cce7add11392983e7402a4bb7ad6fd07

--- a/member/src/main/resources/application.yml
+++ b/member/src/main/resources/application.yml
@@ -60,8 +60,6 @@ spring:
         login: https://nid.naver.com/oauth2.0/authorize
         token: https://nid.naver.com/oauth2.0/token
         profile: https://openapi.naver.com/v1/nid/me
-  url:
-    base: http://localhost:8000
 
 eureka:
   instance:

--- a/member/src/test/java/kr/or/dining_together/member/controller/SignControllerTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/controller/SignControllerTest.java
@@ -23,7 +23,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 
-import kr.or.dining_together.member.dto.UserDto;
+import kr.or.dining_together.member.dto.SignUserDto;
 import kr.or.dining_together.member.jpa.entity.Customer;
 import kr.or.dining_together.member.jpa.entity.UserType;
 import kr.or.dining_together.member.jpa.repo.UserRepository;
@@ -82,21 +82,21 @@ public class SignControllerTest {
 	@Test
 	public void signup() throws Exception {
 		//given
-		UserDto userDto = UserDto.builder()
+		SignUserDto signUserDto = SignUserDto.builder()
 			.email("jifrozen1@naver.com")
 			.name("문지언1")
 			.password("test2222")
-			.roles(Collections.singletonList("ROLE_USER"))
 			.build();
+
 		SignUpRequest signUpRequest = SignUpRequest.builder()
-			.userDto(userDto)
+			.signUserDto(signUserDto)
 			.userType(UserType.CUSTOMER)
 			.age(23)
 			.gender("FEMALE")
 			.build();
 
 		Gson gson = new Gson();
-		String content = gson.toJson(userDto);
+		String content = gson.toJson(signUpRequest);
 
 		System.out.println(content);
 		//when//then

--- a/member/src/test/java/kr/or/dining_together/member/jpa/repo/UserRepositoryTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/jpa/repo/UserRepositoryTest.java
@@ -10,7 +10,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -27,7 +26,6 @@ public class UserRepositoryTest {
 	private PasswordEncoder passwordEncoder;
 
 	@Before
-	@Test
 	public void save() {
 		//given
 		String email = "jifrozen@naver.com";
@@ -51,18 +49,9 @@ public class UserRepositoryTest {
 			.gender("MALE")
 			.build();
 		//when
-		Store newStore = new Store();
-		Customer newCustomer = new Customer();
-		try {
-			newStore = (Store)userRepository.save(store);
-			newCustomer = (Customer)userRepository.save(customer);
-		} catch (DataIntegrityViolationException e) {
-			System.out.println("history already exist");
-		}
+		userRepository.save(store);
+		userRepository.save(customer);
 
-		//then
-		assertEquals(store.getName(), newStore.getName());
-		assertEquals(customer.getName(), newCustomer.getName());
 	}
 
 	@Test

--- a/member/src/test/java/kr/or/dining_together/member/service/UserServiceTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/service/UserServiceTest.java
@@ -2,8 +2,6 @@ package kr.or.dining_together.member.service;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 
 import org.junit.Test;
@@ -33,8 +31,6 @@ public class UserServiceTest {
 
 	@Test
 	public void signUpTest() {
-		//given
-		List<String> roles = Arrays.asList("USER");
 		SignUserDto signUserDto = SignUserDto.builder()
 			.email("qja9605@naver.com")
 			.name("신태범")
@@ -56,4 +52,5 @@ public class UserServiceTest {
 		System.out.println(user);
 		assertEquals(user.get().getEmail(), "qja9605@naver.com");
 	}
+
 }

--- a/member/src/test/java/kr/or/dining_together/member/service/UserServiceTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/service/UserServiceTest.java
@@ -13,7 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import kr.or.dining_together.member.dto.UserDto;
+import kr.or.dining_together.member.dto.SignUserDto;
 import kr.or.dining_together.member.jpa.entity.User;
 import kr.or.dining_together.member.jpa.entity.UserType;
 import kr.or.dining_together.member.jpa.repo.UserRepository;
@@ -35,15 +35,14 @@ public class UserServiceTest {
 	public void signUpTest() {
 		//given
 		List<String> roles = Arrays.asList("USER");
-		UserDto userDto = UserDto.builder()
+		SignUserDto signUserDto = SignUserDto.builder()
 			.email("qja9605@naver.com")
 			.name("신태범")
 			.password("1234")
-			.roles(roles)
 			.build();
 
 		SignUpRequest signUpRequest = SignUpRequest.builder()
-			.userDto(userDto)
+			.signUserDto(signUserDto)
 			.userType(UserType.CUSTOMER)
 			.age(24)
 			.gender("MALE")
@@ -57,5 +56,4 @@ public class UserServiceTest {
 		System.out.println(user);
 		assertEquals(user.get().getEmail(), "qja9605@naver.com");
 	}
-
 }


### PR DESCRIPTION
<img width="1273" alt="image" src="https://user-images.githubusercontent.com/62784314/121483183-db233980-ca08-11eb-9f42-ea903cef0063.png">


# 회원가입 수정
1. 회원가입을 할때 Customer 와 Store 받는 데이터가 다르기 때문에 받는 객체를 두개 만들었습니다. -> StoreSignUpRequest / CustomerSignUpRequest 
이런식으로 안하면 파라미터에 usertype을 받아서 구분해줘야하는데 어차피 회원가입에 필요한 데이터가 다르기 때문에
/signup/store
/signup/customer
로 나눴습니다.
파라미터 Usertype을 받아서 나눈다면 SignUpRequest 객체(성별 나이 포함)에서 Store 저장할때는 성별 나이 없이 저장하는식으로 수정하시면 아마 될것같습니다....

2. entity에 default값을 추가했습니다.
업체 - 서류 제출 여부 - False
User - provider default 값 application



3. user role도 처음에 제가 default값을 ROLE_USER로 설정했기 때문에 회원가입때 따로 받지 않도록 설정햇습니다.
그리고 role은 admin user
user type store customer 이런식으로 나눠야할것같습니다.


------

태범님 그리고 머지할때나 pr할때 store customer같이 두가지 경우로 나눠지는 경우에는 테스트 좀 꼼꼼히 부탁드립니다...(저 같은 경우에는 swagger-ui로 먼저 테스트해서 h2-console에서 확인한 후 테스트 코드를 짜거나 합니다....)
그리고 제가 대충 돌아가도록 수정만 해서 태범님이 마무리 해주시고 머지 후 pr close 해주세요.
제가 수정한 코드 마음에 안드시면 자유롭게 바꿔주셔도 괜찮습니다
만약 수정없이 진행하시려면 안쓰는 객체는(기존 SignUpRequest 같은) 지워주시고 수정 후 머지해주시면 될것같습니다...
그리고 머지하고 develop 브랜치 환경에서도 한번 테스트 부탁드립니다...!!!!!
오늘까지 해주시면 좋을것같은데 혹시 마무리 언제까지 가능하실까요?
