### PR TITLE
Feature#13/api docs

### DIFF
--- a/auction/pom.xml
+++ b/auction/pom.xml
@@ -134,6 +134,13 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin><!--Compile the life cycle of skipping test file inspection-->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>com.github.berkleytechnologyservices.restdocs-spec</groupId>
                 <artifactId>restdocs-spec-maven-plugin</artifactId>

--- a/auction/pom.xml
+++ b/auction/pom.xml
@@ -16,6 +16,9 @@
     <properties>
         <java.version>11</java.version>
         <spring-cloud.version>2020.0.3</spring-cloud.version>
+        <restdocs-api-spec.version>0.10.0</restdocs-api-spec.version>
+        <restdocs-spec.version>0.19</restdocs-spec.version>
+        <asciidoctor.version>2.1.0</asciidoctor.version>
     </properties>
     <dependencies>
         <dependency>
@@ -52,6 +55,18 @@
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>
             <version>2.9.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.epages</groupId>
+            <artifactId>restdocs-api-spec-mockmvc</artifactId>
+            <version>${restdocs-api-spec.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.epages</groupId>
+            <artifactId>restdocs-api-spec</artifactId>
+            <version>${restdocs-api-spec.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -114,7 +129,35 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>com.github.berkleytechnologyservices.restdocs-spec</groupId>
+                <artifactId>restdocs-spec-maven-plugin</artifactId>
+                <version>${restdocs-spec.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <specification>OPENAPI_V3</specification>
+                            <format>JSON</format>
+                            <outputDirectory>${project.build.directory}/classes/static/docs</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
-
+    <repositories>
+        <repository>
+            <id>jcenter</id>
+            <url>https://jcenter.bintray.com</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>jcenter</id>
+            <url>https://jcenter.bintray.com</url>
+        </pluginRepository>
+    </pluginRepositories>
 </project>

--- a/auction/pom.xml
+++ b/auction/pom.xml
@@ -92,6 +92,11 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>
         </dependency>
+        <!-- resilience4j -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-circuitbreaker-resilience4j</artifactId>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/auction/src/main/java/kr/or/dining_together/auction/client/UserServiceClient.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/client/UserServiceClient.java
@@ -1,13 +1,26 @@
 package kr.or.dining_together.auction.client;
 
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 import kr.or.dining_together.auction.dto.UserIdDto;
+import kr.or.dining_together.auction.model.CommonResult;
+import kr.or.dining_together.auction.vo.LoginRequest;
+import kr.or.dining_together.auction.vo.SignUpRequest;
 
 @FeignClient(name = "member")
 public interface UserServiceClient {
 	@GetMapping(value = "/member/userId")
-	public UserIdDto getUserId(@RequestHeader("X-AUTH-TOKEN") String xAuthToken);
+	UserIdDto getUserId(@RequestHeader("X-AUTH-TOKEN") String xAuthToken);
+
+	// @PostMapping(path = "/member/auth/signin")
+	// public ResponseEntity<String> login(@RequestBody LoginRequest loginRequest);
+	//
+	// @PostMapping(path = "/member/auth/signup")
+	// public void userSignUp(@RequestBody SignUpRequest sign);
+
 }

--- a/auction/src/main/java/kr/or/dining_together/auction/client/UserServiceClient.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/client/UserServiceClient.java
@@ -1,16 +1,10 @@
 package kr.or.dining_together.auction.client;
 
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 import kr.or.dining_together.auction.dto.UserIdDto;
-import kr.or.dining_together.auction.model.CommonResult;
-import kr.or.dining_together.auction.vo.LoginRequest;
-import kr.or.dining_together.auction.vo.SignUpRequest;
 
 @FeignClient(name = "member")
 public interface UserServiceClient {

--- a/auction/src/main/java/kr/or/dining_together/auction/controller/AuctionController.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/controller/AuctionController.java
@@ -73,25 +73,19 @@ public class AuctionController {
 	@ApiOperation(value = "사용자별 공고 조회", notes = "사용자별 공고를 불러온다.")
 	@GetMapping(value = "/{userId}/auctions")
 	public ListResult<Auction> getAuction(
-		@PathVariable("userId") String userId) {
+		@PathVariable("userId") long userId) {
 		return responseService.getListResult(auctionService.getAuctionsByUserId(userId));
 	}
 
 	@ApiOperation(value = "공고 수정", notes = "공고 수정 한다.")
 	@PutMapping(value = "/{auctionId}")
-	@ApiImplicitParams({
-		@ApiImplicitParam(name = "X-AUTH-TOKEN", value = "로그인 성공 후 jwt token", required = true, dataType = "String", paramType = "header")
-	})
 	public SingleResult<Auction> modifyAuction(@ApiParam(value = "공고id", required = true) @PathVariable long auctionId,
-		@RequestBody @ApiParam(value = "공고정보", required = true) AuctionDto auctionDto) {
-		return responseService.getSingleResult(auctionService.updateAuction(auctionId, auctionDto));
+		@RequestBody @ApiParam(value = "공고정보", required = true) RequestAuction requestAuction) {
+		return responseService.getSingleResult(auctionService.updateAuction(auctionId, requestAuction));
 	}
 
 	@ApiOperation(value = "공고 삭제", notes = "공고 삭제 한다.")
 	@DeleteMapping(value = "/{auctionId}")
-	@ApiImplicitParams({
-		@ApiImplicitParam(name = "X-AUTH-TOKEN", value = "로그인 성공 후 jwt token", required = true, dataType = "String", paramType = "header")
-	})
 	public CommonResult deleteAuction(@ApiParam(value = "공고id", required = true) @PathVariable long auctionId) {
 		return responseService.getSingleResult(auctionService.deleteAuction(auctionId));
 	}

--- a/auction/src/main/java/kr/or/dining_together/auction/controller/AuctionController.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/controller/AuctionController.java
@@ -78,14 +78,22 @@ public class AuctionController {
 
 	@ApiOperation(value = "공고 수정", notes = "공고 수정 한다.")
 	@PutMapping(value = "/{auctionId}")
-	public SingleResult<Auction> modifyAuction(@ApiParam(value = "공고id", required = true) @PathVariable long auctionId,
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "X-AUTH-TOKEN", value = "로그인 성공 후 jwt token", required = true, dataType = "String", paramType = "header")
+	})
+	public SingleResult<Auction> modifyAuction(@RequestHeader("X-AUTH-TOKEN") String xAuthToken,
+		@ApiParam(value = "공고id", required = true) @PathVariable long auctionId,
 		@RequestBody @ApiParam(value = "공고정보", required = true) RequestAuction requestAuction) {
 		return responseService.getSingleResult(auctionService.updateAuction(auctionId, requestAuction));
 	}
 
 	@ApiOperation(value = "공고 삭제", notes = "공고 삭제 한다.")
 	@DeleteMapping(value = "/{auctionId}")
-	public CommonResult deleteAuction(@ApiParam(value = "공고id", required = true) @PathVariable long auctionId) {
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "X-AUTH-TOKEN", value = "로그인 성공 후 jwt token", required = true, dataType = "String", paramType = "header")
+	})
+	public CommonResult deleteAuction(@RequestHeader("X-AUTH-TOKEN") String xAuthToken,
+		@ApiParam(value = "공고id", required = true) @PathVariable long auctionId) {
 		return responseService.getSingleResult(auctionService.deleteAuction(auctionId));
 	}
 

--- a/auction/src/main/java/kr/or/dining_together/auction/controller/AuctionController.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/controller/AuctionController.java
@@ -16,7 +16,6 @@ import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import kr.or.dining_together.auction.client.UserServiceClient;
-import kr.or.dining_together.auction.dto.AuctionDto;
 import kr.or.dining_together.auction.dto.UserIdDto;
 import kr.or.dining_together.auction.jpa.entity.Auction;
 import kr.or.dining_together.auction.model.CommonResult;

--- a/auction/src/main/java/kr/or/dining_together/auction/controller/AuctioneerController.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/controller/AuctioneerController.java
@@ -1,0 +1,91 @@
+package kr.or.dining_together.auction.controller;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import kr.or.dining_together.auction.client.UserServiceClient;
+import kr.or.dining_together.auction.dto.UserIdDto;
+import kr.or.dining_together.auction.jpa.entity.Auctioneer;
+import kr.or.dining_together.auction.model.CommonResult;
+import kr.or.dining_together.auction.model.ListResult;
+import kr.or.dining_together.auction.model.SingleResult;
+import kr.or.dining_together.auction.service.AuctioneerService;
+import kr.or.dining_together.auction.service.ResponseService;
+import kr.or.dining_together.auction.vo.AuctioneerRequest;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @package : kr.or.dining_together.auction.controller
+ * @name: AuctioneerController.java
+ * @date : 2021/06/16 2:12 오전
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description : 공고 참여 업체 컨트롤러
+ * @modified :
+ **/
+@Api(tags = {"2. Auctioneer"})
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "/auction")
+public class AuctioneerController {
+	private final AuctioneerService auctioneerService;
+	private final ResponseService responseService;
+	private final UserServiceClient userServiceClient;
+
+	@ApiOperation(value = "참여 업체 리스트 조회", notes = "공고에 참여힌 업체 리스트 조회한다.")
+	@GetMapping(value = "/{auctionId}/store")
+	public ListResult<Auctioneer> auctioneers(
+		@ApiParam(value = "공고id", required = true) @PathVariable long auctionId
+	) {
+		return responseService.getListResult(auctioneerService.getAuctioneer(auctionId));
+	}
+
+	@ApiOperation(value = "경매에 업체 참여", notes = "경매에 업체가 참여한다.")
+	@PostMapping("/{auctionId}/store")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "X-AUTH-TOKEN", value = "로그인 성공 후 jwt token", required = true, dataType = "String", paramType = "header")
+	})
+	public SingleResult<Auctioneer> registerAuctioneer(
+		@ApiParam(value = "공고id", required = true) @PathVariable long auctionId,
+		@RequestHeader("X-AUTH-TOKEN") String xAuthToken,
+		@RequestBody @ApiParam(value = "경매 참여 등록 정보", required = true) AuctioneerRequest auctioneerRequest) {
+		UserIdDto user = userServiceClient.getUserId(xAuthToken);
+		return responseService.getSingleResult(
+			auctioneerService.registerAuctioneer(auctioneerRequest, user, auctionId));
+
+	}
+
+	@ApiOperation(value = "참여 업체 수정", notes = "공고에 참여한 업체를 수정 한다.")
+	@PutMapping(value = "/{auctioneerId}")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "X-AUTH-TOKEN", value = "로그인 성공 후 jwt token", required = true, dataType = "String", paramType = "header")
+	})
+	public SingleResult<Auctioneer> modifyAuction(
+		@ApiParam(value = "공고id", required = true) @PathVariable long auctioneerId,
+		@RequestBody @ApiParam(value = "경매 참여 등록 정보", required = true) AuctioneerRequest auctioneerRequest) {
+		return responseService.getSingleResult(auctioneerService.modifyAuctioneer(auctioneerRequest, auctioneerId));
+	}
+
+	@ApiOperation(value = "참여 업체 삭제", notes = "공고에 참여한 업체를 삭제 한다.")
+	@DeleteMapping(value = "/{auctioneerId}")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "X-AUTH-TOKEN", value = "로그인 성공 후 jwt token", required = true, dataType = "String", paramType = "header")
+	})
+	public CommonResult deleteAuction(
+		@ApiParam(value = "공고 참여 업체 id", required = true) @PathVariable long auctioneerId) {
+		return responseService.getSingleResult(auctioneerService.deleteAuctioneer(auctioneerId));
+	}
+
+}

--- a/auction/src/main/java/kr/or/dining_together/auction/controller/AuctioneerController.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/controller/AuctioneerController.java
@@ -73,7 +73,7 @@ public class AuctioneerController {
 	@ApiImplicitParams({
 		@ApiImplicitParam(name = "X-AUTH-TOKEN", value = "로그인 성공 후 jwt token", required = true, dataType = "String", paramType = "header")
 	})
-	public SingleResult<AuctioneerDto> modifyAuction(
+	public SingleResult<AuctioneerDto> modifyAuctioneer(
 		@ApiParam(value = "업체id", required = true) @PathVariable long auctioneerId,
 		@RequestBody @ApiParam(value = "경매 참여 등록 정보", required = true) AuctioneerRequest auctioneerRequest) {
 		return responseService.getSingleResult(auctioneerService.modifyAuctioneer(auctioneerRequest, auctioneerId));
@@ -84,7 +84,7 @@ public class AuctioneerController {
 	@ApiImplicitParams({
 		@ApiImplicitParam(name = "X-AUTH-TOKEN", value = "로그인 성공 후 jwt token", required = true, dataType = "String", paramType = "header")
 	})
-	public CommonResult deleteAuction(
+	public CommonResult deleteAuctioneer(
 		@ApiParam(value = "공고 참여 업체 id", required = true) @PathVariable long auctioneerId) {
 		return responseService.getSingleResult(auctioneerService.deleteAuctioneer(auctioneerId));
 	}

--- a/auction/src/main/java/kr/or/dining_together/auction/controller/AuctioneerController.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/controller/AuctioneerController.java
@@ -49,7 +49,7 @@ public class AuctioneerController {
 	public ListResult<Auctioneer> auctioneers(
 		@ApiParam(value = "공고id", required = true) @PathVariable long auctionId
 	) {
-		return responseService.getListResult(auctioneerService.getAuctioneer(auctionId));
+		return responseService.getListResult(auctioneerService.getAuctioneers(auctionId));
 	}
 
 	@ApiOperation(value = "경매에 업체 참여", notes = "경매에 업체가 참여한다.")
@@ -68,23 +68,23 @@ public class AuctioneerController {
 	}
 
 	@ApiOperation(value = "참여 업체 수정", notes = "공고에 참여한 업체를 수정 한다.")
-	@PutMapping(value = "/{auctioneerId}")
+	@PutMapping(value = "/auction/{auctioneerId}")
 	@ApiImplicitParams({
 		@ApiImplicitParam(name = "X-AUTH-TOKEN", value = "로그인 성공 후 jwt token", required = true, dataType = "String", paramType = "header")
 	})
 	public SingleResult<Auctioneer> modifyAuction(
-		@ApiParam(value = "공고id", required = true) @PathVariable long auctioneerId,
+		@ApiParam(value = "업체id", required = true) @PathVariable long auctioneerId,
 		@RequestBody @ApiParam(value = "경매 참여 등록 정보", required = true) AuctioneerRequest auctioneerRequest) {
 		return responseService.getSingleResult(auctioneerService.modifyAuctioneer(auctioneerRequest, auctioneerId));
 	}
 
 	@ApiOperation(value = "참여 업체 삭제", notes = "공고에 참여한 업체를 삭제 한다.")
-	@DeleteMapping(value = "/{auctioneerId}")
+	@DeleteMapping(value = "/auction/{auctioneerId}")
 	@ApiImplicitParams({
 		@ApiImplicitParam(name = "X-AUTH-TOKEN", value = "로그인 성공 후 jwt token", required = true, dataType = "String", paramType = "header")
 	})
 	public CommonResult deleteAuction(
-		@ApiParam(value = "공고 참여 업체 id", required = true) @PathVariable long auctioneerId) {
+		@ApiParam(value = "공고 참여 업체 id", required = true) @PathVariable long auctioneerId){
 		return responseService.getSingleResult(auctioneerService.deleteAuctioneer(auctioneerId));
 	}
 

--- a/auction/src/main/java/kr/or/dining_together/auction/controller/AuctioneerController.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/controller/AuctioneerController.java
@@ -16,6 +16,7 @@ import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import kr.or.dining_together.auction.client.UserServiceClient;
+import kr.or.dining_together.auction.dto.AuctioneerDto;
 import kr.or.dining_together.auction.dto.UserIdDto;
 import kr.or.dining_together.auction.jpa.entity.Auctioneer;
 import kr.or.dining_together.auction.model.CommonResult;
@@ -45,7 +46,7 @@ public class AuctioneerController {
 	private final UserServiceClient userServiceClient;
 
 	@ApiOperation(value = "참여 업체 리스트 조회", notes = "공고에 참여힌 업체 리스트 조회한다.")
-	@GetMapping(value = "/{auctionId}/store")
+	@GetMapping(value = "/{auctionId}/auctioneers")
 	public ListResult<Auctioneer> auctioneers(
 		@ApiParam(value = "공고id", required = true) @PathVariable long auctionId
 	) {
@@ -53,11 +54,11 @@ public class AuctioneerController {
 	}
 
 	@ApiOperation(value = "경매에 업체 참여", notes = "경매에 업체가 참여한다.")
-	@PostMapping("/{auctionId}/store")
+	@PostMapping("/{auctionId}/auctioneer")
 	@ApiImplicitParams({
 		@ApiImplicitParam(name = "X-AUTH-TOKEN", value = "로그인 성공 후 jwt token", required = true, dataType = "String", paramType = "header")
 	})
-	public SingleResult<Auctioneer> registerAuctioneer(
+	public SingleResult<AuctioneerDto> registerAuctioneer(
 		@ApiParam(value = "공고id", required = true) @PathVariable long auctionId,
 		@RequestHeader("X-AUTH-TOKEN") String xAuthToken,
 		@RequestBody @ApiParam(value = "경매 참여 등록 정보", required = true) AuctioneerRequest auctioneerRequest) {
@@ -68,18 +69,18 @@ public class AuctioneerController {
 	}
 
 	@ApiOperation(value = "참여 업체 수정", notes = "공고에 참여한 업체를 수정 한다.")
-	@PutMapping(value = "/auction/{auctioneerId}")
+	@PutMapping(value = "/auctioneer/{auctioneerId}")
 	@ApiImplicitParams({
 		@ApiImplicitParam(name = "X-AUTH-TOKEN", value = "로그인 성공 후 jwt token", required = true, dataType = "String", paramType = "header")
 	})
-	public SingleResult<Auctioneer> modifyAuction(
+	public SingleResult<AuctioneerDto> modifyAuction(
 		@ApiParam(value = "업체id", required = true) @PathVariable long auctioneerId,
 		@RequestBody @ApiParam(value = "경매 참여 등록 정보", required = true) AuctioneerRequest auctioneerRequest) {
 		return responseService.getSingleResult(auctioneerService.modifyAuctioneer(auctioneerRequest, auctioneerId));
 	}
 
 	@ApiOperation(value = "참여 업체 삭제", notes = "공고에 참여한 업체를 삭제 한다.")
-	@DeleteMapping(value = "/auction/{auctioneerId}")
+	@DeleteMapping(value = "/auctioneer/{auctioneerId}")
 	@ApiImplicitParams({
 		@ApiImplicitParam(name = "X-AUTH-TOKEN", value = "로그인 성공 후 jwt token", required = true, dataType = "String", paramType = "header")
 	})

--- a/auction/src/main/java/kr/or/dining_together/auction/controller/AuctioneerController.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/controller/AuctioneerController.java
@@ -85,7 +85,7 @@ public class AuctioneerController {
 		@ApiImplicitParam(name = "X-AUTH-TOKEN", value = "로그인 성공 후 jwt token", required = true, dataType = "String", paramType = "header")
 	})
 	public CommonResult deleteAuction(
-		@ApiParam(value = "공고 참여 업체 id", required = true) @PathVariable long auctioneerId){
+		@ApiParam(value = "공고 참여 업체 id", required = true) @PathVariable long auctioneerId) {
 		return responseService.getSingleResult(auctioneerService.deleteAuctioneer(auctioneerId));
 	}
 

--- a/auction/src/main/java/kr/or/dining_together/auction/dto/AuctionDto.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/dto/AuctionDto.java
@@ -30,10 +30,10 @@ public class AuctionDto {
 	private String content;
 
 	@ApiModelProperty(notes = "공고 최대 가격")
-	private String maxPrice;
+	private int maxPrice;
 
 	@ApiModelProperty(notes = "공고 최소 가격")
-	private String minPrice;
+	private int minPrice;
 
 	@ApiModelProperty(notes = "단체유형")
 	private String userType;

--- a/auction/src/main/java/kr/or/dining_together/auction/dto/AuctioneerDto.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/dto/AuctioneerDto.java
@@ -1,0 +1,34 @@
+package kr.or.dining_together.auction.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Data
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(value = "AuctioneerDto", description = "공고 참여 업체")
+@Builder
+public class AuctioneerDto {
+	@ApiModelProperty(notes = "참여업체 id")
+	private Long auctioneerId;
+
+	@ApiModelProperty(notes = "업체 id")
+	private long storeId;
+
+	@ApiModelProperty(notes = "업체 메뉴")
+	private String menu;
+
+	@ApiModelProperty(notes = "예상 가격")
+	private int price;
+
+	@ApiModelProperty(notes = "업체 소개")
+	private String content;
+}

--- a/auction/src/main/java/kr/or/dining_together/auction/dto/MenuIdDto.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/dto/MenuIdDto.java
@@ -1,0 +1,4 @@
+package kr.or.dining_together.auction.dto;
+
+public class MenuIdDto {
+}

--- a/auction/src/main/java/kr/or/dining_together/auction/dto/UserIdDto.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/dto/UserIdDto.java
@@ -2,9 +2,17 @@ package kr.or.dining_together.auction.dto;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Builder
+@Getter
+@Setter
+@AllArgsConstructor
 @Data
 @NoArgsConstructor
 @ApiModel(value = "UserIdDto", description = "사용자 아이디 (pkey)")

--- a/auction/src/main/java/kr/or/dining_together/auction/dto/UserIdDto.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/dto/UserIdDto.java
@@ -19,7 +19,7 @@ import lombok.Setter;
 public class UserIdDto {
 
 	@ApiModelProperty(value = "아이디")
-	private String id;
+	private long id;
 
 	@ApiModelProperty(value = "이름")
 	private String name;

--- a/auction/src/main/java/kr/or/dining_together/auction/dto/UserType.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/dto/UserType.java
@@ -1,0 +1,28 @@
+package kr.or.dining_together.auction.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserType {
+	CUSTOMER(Values.CUSTOMER),
+	STORE(Values.STORE),
+	SOCIALUSER(Values.SOCIALUSER),
+	ADMIN(Values.ADMIN);
+
+	private String value;
+
+	UserType(String val) {
+		if (!this.name().equals(val)) {
+			throw new IllegalArgumentException("Incorrect use of UserType");
+		}
+	}
+
+	public static class Values {
+		public static final String CUSTOMER = "CUSTOMER";
+		public static final String STORE = "STORE";
+		public static final String ADMIN = "ADMIN";
+		public static final String SOCIALUSER = "SOCIALUSER";
+	}
+}

--- a/auction/src/main/java/kr/or/dining_together/auction/jpa/entity/Auction.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/jpa/entity/Auction.java
@@ -9,11 +9,12 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
 import javax.persistence.Table;
-import javax.validation.constraints.Past;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -47,9 +48,9 @@ public class Auction {
 	@Column(length = 500)
 	private String content;
 	@ApiModelProperty(notes = "공고 최대 가격")
-	private String maxPrice;
+	private int maxPrice;
 	@ApiModelProperty(notes = "공고 최소 가격")
-	private String minPrice;
+	private int minPrice;
 	@ApiModelProperty(notes = "공고 상태")
 	private String status;
 	@ApiModelProperty(notes = "단체유형")
@@ -61,13 +62,17 @@ public class Auction {
 	@ApiModelProperty(notes = "사용자 id")
 	private String userId;
 
+	@OneToMany(mappedBy = "auction")
+	private List<Auctioneer> auctioneers = new ArrayList<>();
+
 	@ApiModelProperty(notes = "선호 메뉴")
 	@OneToMany(mappedBy = "auction")
 	private List<AuctionStoreType> auctionStoreTypes = new ArrayList<>();
+
 	@PrePersist
 	void prePersist() {
 		this.createdDate = this.updatedDate = new Date();
-		this.status="PROCEEDING";
+		this.status = "PROCEEDING";
 	}
 
 	@PreUpdate
@@ -75,7 +80,7 @@ public class Auction {
 		this.updatedDate = new Date();
 	}
 
-	public void setUpdate(String title, String content, String minPrice, String userType, String maxPrice,
+	public void setUpdate(String title, String content, int minPrice, String userType, int maxPrice,
 		Date reservation, Date deadline) {
 		this.title = title;
 		this.content = content;
@@ -85,5 +90,6 @@ public class Auction {
 		this.reservation = reservation;
 		this.deadline = deadline;
 	}
+
 
 }

--- a/auction/src/main/java/kr/or/dining_together/auction/jpa/entity/Auction.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/jpa/entity/Auction.java
@@ -58,7 +58,7 @@ public class Auction {
 	@ApiModelProperty(notes = "공고 종료 시간")
 	private Date deadline;
 	@ApiModelProperty(notes = "사용자 id")
-	private String userId;
+	private long userId;
 
 	@OneToMany(mappedBy = "auction")
 	private List<Auctioneer> auctioneers = new ArrayList<>();

--- a/auction/src/main/java/kr/or/dining_together/auction/jpa/entity/Auction.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/jpa/entity/Auction.java
@@ -9,9 +9,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
 import javax.persistence.Table;
@@ -90,6 +88,5 @@ public class Auction {
 		this.reservation = reservation;
 		this.deadline = deadline;
 	}
-
 
 }

--- a/auction/src/main/java/kr/or/dining_together/auction/jpa/entity/Auctioneer.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/jpa/entity/Auctioneer.java
@@ -34,7 +34,7 @@ public class Auctioneer {
 	private Auction auction;
 
 	@ApiModelProperty(notes = "업체 id")
-	private String storeId;
+	private long storeId;
 
 	@ApiModelProperty(notes = "업체 메뉴")
 	private String menu;

--- a/auction/src/main/java/kr/or/dining_together/auction/jpa/entity/Auctioneer.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/jpa/entity/Auctioneer.java
@@ -8,6 +8,8 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
@@ -31,6 +33,7 @@ public class Auctioneer {
 
 	@ManyToOne
 	@JoinColumn(name = "auctionId")
+	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
 	private Auction auction;
 
 	@ApiModelProperty(notes = "업체 id")

--- a/auction/src/main/java/kr/or/dining_together/auction/jpa/entity/Auctioneer.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/jpa/entity/Auctioneer.java
@@ -1,0 +1,55 @@
+package kr.or.dining_together.auction.jpa.entity;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Builder
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Table(name = "auctioneer")
+@ApiModel(description = "공고 참여 업체")
+public class Auctioneer {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long auctioneerId;
+
+	@ManyToOne
+	@JoinColumn(name = "auctionId")
+	private Auction auction;
+
+	@ApiModelProperty(notes = "업체 id")
+	private String storeId;
+
+	@ApiModelProperty(notes = "업체 메뉴")
+	private String menu;
+
+	@ApiModelProperty(notes = "예상 가격")
+	private int price;
+
+	@ApiModelProperty(notes = "업체 소개")
+	private String content;
+
+	public void update(String content, String menu, int price) {
+		this.content = content;
+		this.menu = menu;
+		this.price = price;
+	}
+
+}

--- a/auction/src/main/java/kr/or/dining_together/auction/jpa/entity/Auctioneer.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/jpa/entity/Auctioneer.java
@@ -6,7 +6,6 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
 import io.swagger.annotations.ApiModel;

--- a/auction/src/main/java/kr/or/dining_together/auction/jpa/repo/AuctionRepository.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/jpa/repo/AuctionRepository.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import kr.or.dining_together.auction.jpa.entity.Auction;
-import kr.or.dining_together.auction.jpa.entity.Auctioneer;
 
 public interface AuctionRepository extends JpaRepository<Auction, Long> {
 

--- a/auction/src/main/java/kr/or/dining_together/auction/jpa/repo/AuctionRepository.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/jpa/repo/AuctionRepository.java
@@ -5,8 +5,10 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import kr.or.dining_together.auction.jpa.entity.Auction;
+import kr.or.dining_together.auction.jpa.entity.Auctioneer;
 
 public interface AuctionRepository extends JpaRepository<Auction, Long> {
 
-	List<Auction> findAllByUserId(String userId);
+	List<Auction> findAllByUserId(long userId);
+
 }

--- a/auction/src/main/java/kr/or/dining_together/auction/jpa/repo/AuctioneerRepository.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/jpa/repo/AuctioneerRepository.java
@@ -1,0 +1,13 @@
+package kr.or.dining_together.auction.jpa.repo;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.or.dining_together.auction.jpa.entity.Auction;
+import kr.or.dining_together.auction.jpa.entity.Auctioneer;
+
+public interface AuctioneerRepository extends JpaRepository<Auctioneer, Long> {
+
+	List<Auctioneer> findAuctioneersByAuction(Auction auction);
+}

--- a/auction/src/main/java/kr/or/dining_together/auction/service/AuctionService.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/service/AuctionService.java
@@ -7,7 +7,6 @@ import javax.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
 import kr.or.dining_together.auction.advice.exception.ResourceNotExistException;
-import kr.or.dining_together.auction.dto.AuctionDto;
 import kr.or.dining_together.auction.dto.UserIdDto;
 import kr.or.dining_together.auction.jpa.entity.Auction;
 import kr.or.dining_together.auction.jpa.repo.AuctionRepository;
@@ -59,7 +58,8 @@ public class AuctionService {
 	public Auction updateAuction(long auctionId, RequestAuction requestAuction) {
 		Auction auction = getAuction(auctionId);
 		auction.setUpdate(requestAuction.getTitle(), requestAuction.getContent(), requestAuction.getMinPrice(),
-			requestAuction.getUserType(), requestAuction.getMaxPrice(), requestAuction.getReservation(), requestAuction.getDeadline());
+			requestAuction.getUserType(), requestAuction.getMaxPrice(), requestAuction.getReservation(),
+			requestAuction.getDeadline());
 		return auction;
 	}
 

--- a/auction/src/main/java/kr/or/dining_together/auction/service/AuctionService.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/service/AuctionService.java
@@ -37,7 +37,7 @@ public class AuctionService {
 		return auctionRepository.findById(auctionId).orElseThrow(ResourceNotExistException::new);
 	}
 
-	public List<Auction> getAuctionsByUserId(String userId) {
+	public List<Auction> getAuctionsByUserId(long userId) {
 		return auctionRepository.findAllByUserId(userId);
 	}
 
@@ -56,10 +56,10 @@ public class AuctionService {
 		return auctionRepository.save(auction);
 	}
 
-	public Auction updateAuction(long auctionId, AuctionDto auctionDto) {
+	public Auction updateAuction(long auctionId, RequestAuction requestAuction) {
 		Auction auction = getAuction(auctionId);
-		auction.setUpdate(auctionDto.getTitle(), auctionDto.getContent(), auctionDto.getMinPrice(),
-			auctionDto.getUserType(), auction.getMaxPrice(), auctionDto.getReservation(), auctionDto.getDeadline());
+		auction.setUpdate(requestAuction.getTitle(), requestAuction.getContent(), requestAuction.getMinPrice(),
+			requestAuction.getUserType(), requestAuction.getMaxPrice(), requestAuction.getReservation(), requestAuction.getDeadline());
 		return auction;
 	}
 

--- a/auction/src/main/java/kr/or/dining_together/auction/service/AuctioneerService.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/service/AuctioneerService.java
@@ -1,0 +1,70 @@
+package kr.or.dining_together.auction.service;
+
+import java.util.List;
+
+import javax.transaction.Transactional;
+
+import org.springframework.stereotype.Service;
+
+import kr.or.dining_together.auction.advice.exception.ResourceNotExistException;
+import kr.or.dining_together.auction.dto.UserIdDto;
+import kr.or.dining_together.auction.jpa.entity.Auction;
+import kr.or.dining_together.auction.jpa.entity.Auctioneer;
+import kr.or.dining_together.auction.jpa.repo.AuctionRepository;
+import kr.or.dining_together.auction.jpa.repo.AuctioneerRepository;
+import kr.or.dining_together.auction.vo.AuctioneerRequest;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @package : kr.or.dining_together.auction.service
+ * @name: AuctioneerService.java
+ * @date : 2021/06/16 2:12 오전
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description :
+ * @modified :
+ **/
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuctioneerService {
+
+	private final AuctioneerRepository auctioneerRepository;
+	private final AuctionRepository auctionRepository;
+
+	public List<Auctioneer> getAuctioneer(long auctionId) {
+		Auction auction = auctionRepository.findById(auctionId).orElseThrow(ResourceNotExistException::new);
+		return auctioneerRepository.findAuctioneersByAuction(auction);
+	}
+
+	public Auctioneer registerAuctioneer(AuctioneerRequest auctioneerRequest, UserIdDto userIdDto, long auctionId) {
+		Auction auction = auctionRepository.findById(auctionId).orElseThrow(ResourceNotExistException::new);
+
+		Auctioneer auctioneer = Auctioneer.builder()
+			.content(auctioneerRequest.getContent())
+			.auction(auction)
+			.price(auctioneerRequest.getPrice())
+			.menu(auctioneerRequest.getMenu())
+			.storeId(userIdDto.getId())
+			.build();
+
+		auctioneerRepository.save(auctioneer);
+
+		return auctioneer;
+	}
+
+	public Auctioneer modifyAuctioneer(AuctioneerRequest auctioneerRequest, long auctioneerId) {
+		Auctioneer auctioneer = auctioneerRepository.findById(auctioneerId).orElseThrow(ResourceNotExistException::new);
+
+		auctioneer.update(auctioneerRequest.getContent(), auctioneer.getMenu(), auctioneerRequest.getPrice());
+		return auctioneer;
+	}
+
+	public boolean deleteAuctioneer(long auctioneerId) {
+		Auctioneer auctioneer = auctioneerRepository.findById(auctioneerId).orElseThrow(ResourceNotExistException::new);
+
+		auctioneerRepository.delete(auctioneer);
+		return true;
+	}
+
+}

--- a/auction/src/main/java/kr/or/dining_together/auction/service/AuctioneerService.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/service/AuctioneerService.java
@@ -4,9 +4,12 @@ import java.util.List;
 
 import javax.transaction.Transactional;
 
+import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
+import org.springframework.ui.ModelMap;
 
 import kr.or.dining_together.auction.advice.exception.ResourceNotExistException;
+import kr.or.dining_together.auction.dto.AuctioneerDto;
 import kr.or.dining_together.auction.dto.UserIdDto;
 import kr.or.dining_together.auction.jpa.entity.Auction;
 import kr.or.dining_together.auction.jpa.entity.Auctioneer;
@@ -34,10 +37,10 @@ public class AuctioneerService {
 
 	public List<Auctioneer> getAuctioneers(long auctionId) {
 		Auction auction = auctionRepository.findById(auctionId).orElseThrow(ResourceNotExistException::new);
-		return auctioneerRepository.findAuctioneersByAuction(auction);
+		return auction.getAuctioneers();
 	}
 
-	public Auctioneer registerAuctioneer(AuctioneerRequest auctioneerRequest, UserIdDto userIdDto, long auctionId) {
+	public AuctioneerDto registerAuctioneer(AuctioneerRequest auctioneerRequest, UserIdDto userIdDto, long auctionId) {
 		Auction auction = auctionRepository.findById(auctionId).orElseThrow(ResourceNotExistException::new);
 
 		Auctioneer auctioneer = Auctioneer.builder()
@@ -50,18 +53,19 @@ public class AuctioneerService {
 
 		auctioneerRepository.save(auctioneer);
 
-		return auctioneer;
+		return new ModelMapper().map(auctioneer,AuctioneerDto.class);
 	}
 
-	public Auctioneer modifyAuctioneer(AuctioneerRequest auctioneerRequest, long auctioneerId) {
+	public AuctioneerDto modifyAuctioneer(AuctioneerRequest auctioneerRequest, long auctioneerId) {
 
 		Auctioneer auctioneer = auctioneerRepository.findById(auctioneerId).orElseThrow(ResourceNotExistException::new);
 
 		auctioneer.update(auctioneerRequest.getContent(), auctioneer.getMenu(), auctioneerRequest.getPrice());
-		return auctioneer;
+		return new ModelMapper().map(auctioneer,AuctioneerDto.class);
 	}
 
 	public boolean deleteAuctioneer(long auctioneerId) {
+
 		Auctioneer auctioneer = auctioneerRepository.findById(auctioneerId).orElseThrow(ResourceNotExistException::new);
 
 		auctioneerRepository.delete(auctioneer);

--- a/auction/src/main/java/kr/or/dining_together/auction/service/AuctioneerService.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/service/AuctioneerService.java
@@ -32,7 +32,7 @@ public class AuctioneerService {
 	private final AuctioneerRepository auctioneerRepository;
 	private final AuctionRepository auctionRepository;
 
-	public List<Auctioneer> getAuctioneer(long auctionId) {
+	public List<Auctioneer> getAuctioneers(long auctionId) {
 		Auction auction = auctionRepository.findById(auctionId).orElseThrow(ResourceNotExistException::new);
 		return auctioneerRepository.findAuctioneersByAuction(auction);
 	}
@@ -54,6 +54,7 @@ public class AuctioneerService {
 	}
 
 	public Auctioneer modifyAuctioneer(AuctioneerRequest auctioneerRequest, long auctioneerId) {
+
 		Auctioneer auctioneer = auctioneerRepository.findById(auctioneerId).orElseThrow(ResourceNotExistException::new);
 
 		auctioneer.update(auctioneerRequest.getContent(), auctioneer.getMenu(), auctioneerRequest.getPrice());

--- a/auction/src/main/java/kr/or/dining_together/auction/service/AuctioneerService.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/service/AuctioneerService.java
@@ -6,7 +6,6 @@ import javax.transaction.Transactional;
 
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
-import org.springframework.ui.ModelMap;
 
 import kr.or.dining_together.auction.advice.exception.ResourceNotExistException;
 import kr.or.dining_together.auction.dto.AuctioneerDto;
@@ -53,7 +52,7 @@ public class AuctioneerService {
 
 		auctioneerRepository.save(auctioneer);
 
-		return new ModelMapper().map(auctioneer,AuctioneerDto.class);
+		return new ModelMapper().map(auctioneer, AuctioneerDto.class);
 	}
 
 	public AuctioneerDto modifyAuctioneer(AuctioneerRequest auctioneerRequest, long auctioneerId) {
@@ -61,7 +60,7 @@ public class AuctioneerService {
 		Auctioneer auctioneer = auctioneerRepository.findById(auctioneerId).orElseThrow(ResourceNotExistException::new);
 
 		auctioneer.update(auctioneerRequest.getContent(), auctioneer.getMenu(), auctioneerRequest.getPrice());
-		return new ModelMapper().map(auctioneer,AuctioneerDto.class);
+		return new ModelMapper().map(auctioneer, AuctioneerDto.class);
 	}
 
 	public boolean deleteAuctioneer(long auctioneerId) {

--- a/auction/src/main/java/kr/or/dining_together/auction/service/AuctioneerService.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/service/AuctioneerService.java
@@ -36,7 +36,8 @@ public class AuctioneerService {
 
 	public List<Auctioneer> getAuctioneers(long auctionId) {
 		Auction auction = auctionRepository.findById(auctionId).orElseThrow(ResourceNotExistException::new);
-		return auction.getAuctioneers();
+		List<Auctioneer> auctioneers = auctioneerRepository.findAuctioneersByAuction(auction);
+		return auctioneers;
 	}
 
 	public AuctioneerDto registerAuctioneer(AuctioneerRequest auctioneerRequest, UserIdDto userIdDto, long auctionId) {

--- a/auction/src/main/java/kr/or/dining_together/auction/vo/AuctioneerRequest.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/vo/AuctioneerRequest.java
@@ -1,7 +1,5 @@
 package kr.or.dining_together.auction.vo;
 
-import java.util.Date;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,12 +13,12 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class RequestAuction {
-	private String title;
-	private String content;
-	private int maxPrice;
-	private int minPrice;
-	private String userType;
-	private Date reservation;
-	private Date deadline;
+public class AuctioneerRequest {
+
+	int price;
+
+	String menu;
+
+	String content;
+
 }

--- a/auction/src/main/java/kr/or/dining_together/auction/vo/LoginRequest.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/vo/LoginRequest.java
@@ -1,0 +1,23 @@
+package kr.or.dining_together.auction.vo;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotNull;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Data
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginRequest {
+	@NotNull(message = "이메일은 빈칸일수 없습니다.")
+	@Email
+	private String email;
+	@NotNull(message = "비밀번호는 빈칸일수 없습니다.")
+	private String password;
+}

--- a/auction/src/main/java/kr/or/dining_together/auction/vo/SignUpRequest.java
+++ b/auction/src/main/java/kr/or/dining_together/auction/vo/SignUpRequest.java
@@ -1,0 +1,25 @@
+package kr.or.dining_together.auction.vo;
+
+import kr.or.dining_together.auction.dto.UserType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Data
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SignUpRequest {
+	private String email;
+	private String name;
+	private String password;
+	private UserType userType;
+	private int age;
+	private String gender;
+
+}

--- a/auction/src/main/resources/application.yml
+++ b/auction/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
       path: /auction/h2-console
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/auction/src/test/java/kr/or/dining_together/auction/controller/AuctionControllerTest.java
+++ b/auction/src/test/java/kr/or/dining_together/auction/controller/AuctionControllerTest.java
@@ -1,0 +1,138 @@
+package kr.or.dining_together.auction.controller;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Date;
+
+import javax.transaction.Transactional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import kr.or.dining_together.auction.client.UserServiceClient;
+import kr.or.dining_together.auction.dto.UserIdDto;
+import kr.or.dining_together.auction.jpa.entity.Auction;
+import kr.or.dining_together.auction.jpa.repo.AuctionRepository;
+import kr.or.dining_together.auction.service.AuctionService;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc
+@Transactional
+class AuctionControllerTest {
+
+	@Autowired
+	AuctionRepository auctionRepository;
+	@Autowired
+	AuctionService auctionService;
+	@Autowired
+	UserServiceClient userServiceClient;
+	@Autowired
+	ModelMapper modelMapper;
+	Auction auction;
+	UserIdDto userIdDto;
+	@Autowired
+	private MockMvc mockMvc;
+
+	@BeforeEach
+	void setUp() {
+
+		userIdDto = UserIdDto.builder()
+			.id("1")
+			.name("moon")
+			.build();
+
+		auction = Auction.builder()
+			.title("제목")
+			.content("내용")
+			.maxPrice(1000)
+			.minPrice(10)
+			.userType("Family")
+			.userId("1")
+			.reservation(new Date())
+			.deadline(new Date())
+			.build();
+
+		auctionRepository.save(auction);
+	}
+
+	@Test
+	void auctions() throws Exception {
+		FieldDescriptor[] auction = new FieldDescriptor[] {
+			fieldWithPath("auctionId").description("Title of the book"),
+			fieldWithPath("title").description("Title of the book"),
+			fieldWithPath("content").description("Author of the book"),
+			fieldWithPath("maxPrice").description("Title of the book"),
+			fieldWithPath("minPrice").description("Title of the book"),
+			fieldWithPath("userType").description("Title of the book"),
+			fieldWithPath("userId").description("Title of the book"),
+			fieldWithPath("reservation").description("Title of the book"),
+			fieldWithPath("userId").description("Title of the book"),
+			fieldWithPath("auctioneer").description("Title of the book"),
+			fieldWithPath("auctionStoreTypes").description("Title of the book"),
+			fieldWithPath("createdDate").description("Title of the book"),
+			fieldWithPath("updatedDate").description("Title of the book")
+		};
+
+		mockMvc.perform(RestDocumentationRequestBuilders.
+			get("/auction/auctions"))
+			.andDo(print())
+			.andExpect(status().isOk())
+
+			.andDo(document("getAuctions",
+				responseFields(
+					fieldWithPath("success").description("성공여부"),
+					fieldWithPath("code").description("코드번호"),
+					fieldWithPath("msg").description("메시지"),
+					fieldWithPath("list.[].auctionId").description("Title of the book"),
+					fieldWithPath("list.[].title").description("Title of the book"),
+					fieldWithPath("list.[].content").description("Author of the book"),
+					fieldWithPath("list.[].maxPrice").description("Title of the book"),
+					fieldWithPath("list.[].minPrice").description("Title of the book"),
+					fieldWithPath("list.[].userType").description("Title of the book"),
+					fieldWithPath("list.[].userId").description("Title of the book"),
+					fieldWithPath("list.[].reservation").description("Title of the book"),
+					fieldWithPath("list.[].userId").description("Title of the book"),
+					fieldWithPath("list.[].status").description("Title of the book"),
+					fieldWithPath("list.[].deadline").description("Title of the book"),
+					fieldWithPath("list.[].auctioneers").description("Title of the book"),
+					fieldWithPath("list.[].auctionStoreTypes").description("Title of the book"),
+					fieldWithPath("list.[].createdDate").description("Title of the book"),
+					fieldWithPath("list.[].updatedDate").description("Title of the book")
+				)));
+	}
+
+	@Test
+	void auction() {
+	}
+
+	@Test
+	void registerAuction() {
+	}
+
+	@Test
+	void getAuction() {
+	}
+
+	@Test
+	void modifyAuction() {
+	}
+
+	@Test
+	void deleteAuction() {
+	}
+}

--- a/auction/src/test/java/kr/or/dining_together/auction/controller/AuctionControllerTest.java
+++ b/auction/src/test/java/kr/or/dining_together/auction/controller/AuctionControllerTest.java
@@ -1,7 +1,6 @@
 package kr.or.dining_together.auction.controller;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -22,7 +21,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
-import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -31,13 +29,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.or.dining_together.auction.client.UserServiceClient;
 import kr.or.dining_together.auction.dto.AuctionDto;
 import kr.or.dining_together.auction.dto.UserIdDto;
-import kr.or.dining_together.auction.dto.UserType;
 import kr.or.dining_together.auction.jpa.entity.Auction;
 import kr.or.dining_together.auction.jpa.repo.AuctionRepository;
 import kr.or.dining_together.auction.service.AuctionService;
-import kr.or.dining_together.auction.vo.LoginRequest;
 import kr.or.dining_together.auction.vo.RequestAuction;
-import kr.or.dining_together.auction.vo.SignUpRequest;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -54,15 +49,14 @@ class AuctionControllerTest {
 	UserServiceClient userServiceClient;
 	@Autowired
 	ModelMapper modelMapper;
-	@Autowired
-	private ObjectMapper objectMapper;
 	UserIdDto userIdDto;
-	@Autowired
-	private MockMvc mockMvc;
 	Auction auction;
-
 	ResponseEntity<String> token;
 	long auctionId;
+	@Autowired
+	private ObjectMapper objectMapper;
+	@Autowired
+	private MockMvc mockMvc;
 
 	@BeforeEach
 	void setUp() {
@@ -82,7 +76,6 @@ class AuctionControllerTest {
 		//
 		// token=userServiceClient.login(loginRequest);
 
-
 		userIdDto = UserIdDto.builder()
 			.id(1L)
 			.name("moon")
@@ -100,8 +93,8 @@ class AuctionControllerTest {
 			.deadline(new Date())
 			.build();
 
-		auction=auctionRepository.save(auction1);
-		auctionId=auction.getAuctionId();
+		auction = auctionRepository.save(auction1);
+		auctionId = auction.getAuctionId();
 	}
 
 	@AfterEach
@@ -138,11 +131,12 @@ class AuctionControllerTest {
 					fieldWithPath("list.[].updatedDate").description("공고 수정 일자")
 				)));
 	}
+
 	@Test
 	void deleteAuction() throws Exception {
 		System.out.println(auction.getAuctionId());
 		mockMvc.perform(RestDocumentationRequestBuilders.
-			delete("/auction/{auctionId}",auction.getAuctionId()))
+			delete("/auction/{auctionId}", auction.getAuctionId()))
 			.andDo(print())
 			.andExpect(status().isOk())
 
@@ -156,11 +150,12 @@ class AuctionControllerTest {
 				)));
 
 	}
+
 	@Test
 	void auction() throws Exception {
 		System.out.println(auction.getAuctionId());
 		mockMvc.perform(RestDocumentationRequestBuilders.
-			get("/auction/{auctionId}",auction.getAuctionId()))
+			get("/auction/{auctionId}", auction.getAuctionId()))
 			.andDo(print())
 			.andExpect(status().isOk())
 
@@ -189,7 +184,6 @@ class AuctionControllerTest {
 	@Test
 	void registerAuction() throws Exception {
 
-
 		RequestAuction auction1 = RequestAuction.builder()
 			.title("제목1")
 			.content("내용1")
@@ -207,7 +201,8 @@ class AuctionControllerTest {
 			.content(content)
 			.contentType(MediaType.APPLICATION_JSON)
 			.accept(MediaType.APPLICATION_JSON)
-			.header("X-AUTH-TOKEN", "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwicm9sZXMiOlsiUk9MRV9VU0VSIl0sImlhdCI6MTYyNDM2ODQ1MSwiZXhwIjoxNjI0NDU0ODUxfQ.SbpFIaWYFyji-izTgGqrzP--bCr-fSw4LhDu0JOoPA8"))
+			.header("X-AUTH-TOKEN",
+				"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwicm9sZXMiOlsiUk9MRV9VU0VSIl0sImlhdCI6MTYyNDM2ODQ1MSwiZXhwIjoxNjI0NDU0ODUxfQ.SbpFIaWYFyji-izTgGqrzP--bCr-fSw4LhDu0JOoPA8"))
 			.andDo(print())
 			.andExpect(status().isOk())
 
@@ -237,7 +232,7 @@ class AuctionControllerTest {
 	void getAuction() throws Exception {
 		System.out.println(auction.getAuctionId());
 		mockMvc.perform(RestDocumentationRequestBuilders.
-			get("/auction/{userId}/auctions","1"))
+			get("/auction/{userId}/auctions", "1"))
 			.andDo(print())
 			.andExpect(status().isOk())
 
@@ -267,17 +262,17 @@ class AuctionControllerTest {
 	void modifyAuction() throws Exception {
 		System.out.println(auction.getAuctionId());
 
-		AuctionDto auction1 =modelMapper.map(auction,AuctionDto.class);
+		AuctionDto auction1 = modelMapper.map(auction, AuctionDto.class);
 
 		auction1.setContent("수정");
 
 		String content = objectMapper.writeValueAsString(auction1);
 
 		mockMvc.perform(RestDocumentationRequestBuilders.
-			put("/auction/{auctionId}",auction.getAuctionId())
-				.content(content)
-				.contentType(MediaType.APPLICATION_JSON)
-				.accept(MediaType.APPLICATION_JSON))
+			put("/auction/{auctionId}", auction.getAuctionId())
+			.content(content)
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON))
 			.andDo(print())
 			.andExpect(status().isOk())
 
@@ -302,8 +297,6 @@ class AuctionControllerTest {
 					fieldWithPath("data.updatedDate").description("공고 수정 일자")
 				)));
 
-
 	}
-
 
 }

--- a/auction/src/test/java/kr/or/dining_together/auction/controller/AuctionControllerTest.java
+++ b/auction/src/test/java/kr/or/dining_together/auction/controller/AuctionControllerTest.java
@@ -1,6 +1,7 @@
 package kr.or.dining_together.auction.controller;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -19,7 +20,6 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -51,8 +51,8 @@ class AuctionControllerTest {
 	ModelMapper modelMapper;
 	UserIdDto userIdDto;
 	Auction auction;
-	ResponseEntity<String> token;
 	long auctionId;
+	String token;
 	@Autowired
 	private ObjectMapper objectMapper;
 	@Autowired
@@ -60,7 +60,8 @@ class AuctionControllerTest {
 
 	@BeforeEach
 	void setUp() {
-
+		token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwicm9sZXMiOlsiUk9MRV9VU0VSIl0sImlhdCI6MTYyNDQyMDI1MSwiZXhwIjoxNjI0NTA2NjUxfQ.beMJYnqZAF1WoTvumtmZiePrU4XmaHsqjBWrWvO2B60";
+		userIdDto = userServiceClient.getUserId(token);
 		// SignUpRequest sign=SignUpRequest.builder()
 		// 	.email("test@test.com")
 		// 	.name("test1")
@@ -76,11 +77,6 @@ class AuctionControllerTest {
 		//
 		// token=userServiceClient.login(loginRequest);
 
-		userIdDto = UserIdDto.builder()
-			.id(1L)
-			.name("moon")
-			.build();
-
 		System.out.println(userIdDto.getId());
 		Auction auction1 = Auction.builder()
 			.title("제목")
@@ -88,7 +84,7 @@ class AuctionControllerTest {
 			.maxPrice(1000)
 			.minPrice(10)
 			.userType("Family")
-			.userId(1L)
+			.userId(userIdDto.getId())
 			.reservation(new Date())
 			.deadline(new Date())
 			.build();
@@ -136,11 +132,16 @@ class AuctionControllerTest {
 	void deleteAuction() throws Exception {
 		System.out.println(auction.getAuctionId());
 		mockMvc.perform(RestDocumentationRequestBuilders.
-			delete("/auction/{auctionId}", auction.getAuctionId()))
+			delete("/auction/{auctionId}", auction.getAuctionId())
+			.header("X-AUTH-TOKEN",
+				token))
 			.andDo(print())
 			.andExpect(status().isOk())
 
 			.andDo(document("deleteAuction",
+				requestHeaders(
+					headerWithName("X-AUTH-TOKEN").description(
+						"토큰값")),
 				responseFields(
 					fieldWithPath("success").description("성공여부"),
 					fieldWithPath("code").description("코드번호"),
@@ -202,11 +203,14 @@ class AuctionControllerTest {
 			.contentType(MediaType.APPLICATION_JSON)
 			.accept(MediaType.APPLICATION_JSON)
 			.header("X-AUTH-TOKEN",
-				"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwicm9sZXMiOlsiUk9MRV9VU0VSIl0sImlhdCI6MTYyNDM2ODQ1MSwiZXhwIjoxNjI0NDU0ODUxfQ.SbpFIaWYFyji-izTgGqrzP--bCr-fSw4LhDu0JOoPA8"))
+				token))
 			.andDo(print())
 			.andExpect(status().isOk())
 
 			.andDo(document("registerAuction",
+				requestHeaders(
+					headerWithName("X-AUTH-TOKEN").description(
+						"토큰값")),
 				responseFields(
 					fieldWithPath("success").description("성공여부"),
 					fieldWithPath("code").description("코드번호"),
@@ -272,11 +276,16 @@ class AuctionControllerTest {
 			put("/auction/{auctionId}", auction.getAuctionId())
 			.content(content)
 			.contentType(MediaType.APPLICATION_JSON)
-			.accept(MediaType.APPLICATION_JSON))
+			.accept(MediaType.APPLICATION_JSON)
+			.header("X-AUTH-TOKEN",
+				token))
 			.andDo(print())
 			.andExpect(status().isOk())
 
 			.andDo(document("modifyAuction",
+				requestHeaders(
+					headerWithName("X-AUTH-TOKEN").description(
+						"토큰값")),
 				responseFields(
 					fieldWithPath("success").description("성공여부"),
 					fieldWithPath("code").description("코드번호"),

--- a/auction/src/test/java/kr/or/dining_together/auction/controller/AuctioneerControllerTest.java
+++ b/auction/src/test/java/kr/or/dining_together/auction/controller/AuctioneerControllerTest.java
@@ -1,12 +1,5 @@
 package kr.or.dining_together.auction.controller;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
 import java.util.Date;
 
 import javax.transaction.Transactional;
@@ -30,7 +23,6 @@ import kr.or.dining_together.auction.jpa.entity.Auction;
 import kr.or.dining_together.auction.jpa.entity.Auctioneer;
 import kr.or.dining_together.auction.jpa.repo.AuctionRepository;
 import kr.or.dining_together.auction.jpa.repo.AuctioneerRepository;
-import kr.or.dining_together.auction.service.AuctionService;
 import kr.or.dining_together.auction.service.AuctioneerService;
 
 @RunWith(SpringRunner.class)
@@ -50,14 +42,14 @@ class AuctioneerControllerTest {
 	UserServiceClient userServiceClient;
 	@Autowired
 	ModelMapper modelMapper;
+	UserIdDto userIdDto;
+	Auction auction;
+	Auctioneer auctioneer;
 	@Autowired
 	private ObjectMapper objectMapper;
-	UserIdDto userIdDto;
 	@Autowired
 	private MockMvc mockMvc;
 
-	Auction auction;
-	Auctioneer auctioneer;
 	@BeforeEach
 	void setUp() {
 		userIdDto = UserIdDto.builder()
@@ -77,9 +69,9 @@ class AuctioneerControllerTest {
 			.deadline(new Date())
 			.build();
 
-		auction=auctionRepository.save(auction1);
+		auction = auctionRepository.save(auction1);
 
-		Auctioneer auctioneer1=Auctioneer.builder()
+		Auctioneer auctioneer1 = Auctioneer.builder()
 			.menu("menu")
 			.auction(auction)
 			.content("content")
@@ -87,7 +79,7 @@ class AuctioneerControllerTest {
 			.storeId(1L)
 			.build();
 
-		auctioneer=auctioneerRepository.save(auctioneer1);
+		auctioneer = auctioneerRepository.save(auctioneer1);
 	}
 
 	@Test

--- a/auction/src/test/java/kr/or/dining_together/auction/controller/AuctioneerControllerTest.java
+++ b/auction/src/test/java/kr/or/dining_together/auction/controller/AuctioneerControllerTest.java
@@ -1,5 +1,11 @@
 package kr.or.dining_together.auction.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
 import java.util.Date;
 
 import javax.transaction.Transactional;
@@ -12,11 +18,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import kr.or.dining_together.auction.advice.exception.ResourceNotExistException;
 import kr.or.dining_together.auction.client.UserServiceClient;
 import kr.or.dining_together.auction.dto.UserIdDto;
 import kr.or.dining_together.auction.jpa.entity.Auction;
@@ -24,6 +33,7 @@ import kr.or.dining_together.auction.jpa.entity.Auctioneer;
 import kr.or.dining_together.auction.jpa.repo.AuctionRepository;
 import kr.or.dining_together.auction.jpa.repo.AuctioneerRepository;
 import kr.or.dining_together.auction.service.AuctioneerService;
+import kr.or.dining_together.auction.vo.AuctioneerRequest;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -45,6 +55,7 @@ class AuctioneerControllerTest {
 	UserIdDto userIdDto;
 	Auction auction;
 	Auctioneer auctioneer;
+	String token;
 	@Autowired
 	private ObjectMapper objectMapper;
 	@Autowired
@@ -52,10 +63,8 @@ class AuctioneerControllerTest {
 
 	@BeforeEach
 	void setUp() {
-		userIdDto = UserIdDto.builder()
-			.id(1L)
-			.name("moon")
-			.build();
+		token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwicm9sZXMiOlsiUk9MRV9VU0VSIl0sImlhdCI6MTYyNDQyMDI1MSwiZXhwIjoxNjI0NTA2NjUxfQ.beMJYnqZAF1WoTvumtmZiePrU4XmaHsqjBWrWvO2B60";
+		userIdDto = userServiceClient.getUserId(token);
 
 		System.out.println(userIdDto.getId());
 		Auction auction1 = Auction.builder()
@@ -64,7 +73,7 @@ class AuctioneerControllerTest {
 			.maxPrice(1000)
 			.minPrice(10)
 			.userType("Family")
-			.userId(1L)
+			.userId(userIdDto.getId())
 			.reservation(new Date())
 			.deadline(new Date())
 			.build();
@@ -76,26 +85,137 @@ class AuctioneerControllerTest {
 			.auction(auction)
 			.content("content")
 			.price(1)
-			.storeId(1L)
+			.storeId(userIdDto.getId())
 			.build();
 
 		auctioneer = auctioneerRepository.save(auctioneer1);
 	}
 
 	@Test
-	void auctioneers() {
+	void auctioneers() throws Exception {
+
+		System.out.println(auction.getAuctionId());
+		Auction auction1 = auctionRepository.findById(auction.getAuctionId())
+			.orElseThrow(ResourceNotExistException::new);
+
+		Auctioneer auctioneer1 = Auctioneer.builder()
+			.menu("menu1")
+			.auction(auction1)
+			.content("content1")
+			.price(1)
+			.storeId(userIdDto.getId())
+			.build();
+
+		Auctioneer auctioneer = auctioneerRepository.save(auctioneer1);
+
+		mockMvc.perform(RestDocumentationRequestBuilders.
+			get("/auction/{auctionId}/auctioneers", auction1.getAuctionId()))
+			.andDo(print())
+			.andExpect(status().isOk())
+
+			.andDo(document("auctioneers",
+				responseFields(
+					fieldWithPath("success").description("성공여부"),
+					fieldWithPath("code").description("코드번호"),
+					fieldWithPath("msg").description("메시지"),
+					fieldWithPath("list.[].auctioneerId").description("Auctioneer ID"),
+					fieldWithPath("list.[].storeId").description("참여 업체 id"),
+					fieldWithPath("list.[].menu").description("추천 메뉴"),
+					fieldWithPath("list.[].price").description("예상 가격"),
+					fieldWithPath("list.[].content").description("내용")
+				)));
 
 	}
 
 	@Test
-	void registerAuctioneer() {
+	void registerAuctioneer() throws Exception {
+		AuctioneerRequest auctioneerRequest = AuctioneerRequest.builder()
+			.price(10)
+			.menu("menu")
+			.content("content")
+			.build();
+
+		String content = objectMapper.writeValueAsString(auctioneerRequest);
+
+		mockMvc.perform(RestDocumentationRequestBuilders.
+			post("/auction/{auctionId}/auctioneer", auction.getAuctionId())
+			.content(content)
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
+			.header("X-AUTH-TOKEN", token))
+			.andDo(print())
+			.andExpect(status().isOk())
+
+			.andDo(document("registerAuctioneer",
+				requestHeaders(
+					headerWithName("X-AUTH-TOKEN").description(
+						"토큰값")),
+				responseFields(
+					fieldWithPath("success").description("성공여부"),
+					fieldWithPath("code").description("코드번호"),
+					fieldWithPath("msg").description("메시지"),
+					fieldWithPath("data.auctioneerId").description("Auctioneer ID"),
+					fieldWithPath("data.storeId").description("참여 업체 id"),
+					fieldWithPath("data.menu").description("추천 메뉴"),
+					fieldWithPath("data.price").description("예상 가격"),
+					fieldWithPath("data.content").description("내용")
+				)));
 	}
 
 	@Test
-	void modifyAuction() {
+	void modifyAuctioneer() throws Exception {
+
+		AuctioneerRequest auctioneerRequest = AuctioneerRequest.builder()
+			.price(10)
+			.menu("수정")
+			.content("수정")
+			.build();
+
+		String content = objectMapper.writeValueAsString(auctioneerRequest);
+
+		mockMvc.perform(RestDocumentationRequestBuilders.
+			put("/auction/auctioneer/{auctioneerId}", auctioneer.getAuctioneerId())
+			.content(content)
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
+			.header("X-AUTH-TOKEN", token))
+			.andDo(print())
+			.andExpect(status().isOk())
+
+			.andDo(document("modifyAuctioneer",
+				requestHeaders(
+					headerWithName("X-AUTH-TOKEN").description(
+						"토큰값")),
+				responseFields(
+					fieldWithPath("success").description("성공여부"),
+					fieldWithPath("code").description("코드번호"),
+					fieldWithPath("msg").description("메시지"),
+					fieldWithPath("data.auctioneerId").description("Auctioneer ID"),
+					fieldWithPath("data.storeId").description("참여 업체 id"),
+					fieldWithPath("data.menu").description("추천 메뉴"),
+					fieldWithPath("data.price").description("예상 가격"),
+					fieldWithPath("data.content").description("내용")
+				)));
 	}
 
 	@Test
-	void deleteAuction() {
+	void deleteAuctioneer() throws Exception {
+		mockMvc.perform(RestDocumentationRequestBuilders.
+			delete("/auction/auctioneer/{auctioneerId}", auctioneer.getAuctioneerId())
+			.header("X-AUTH-TOKEN", token))
+			.andDo(print())
+			.andExpect(status().isOk())
+
+			.andDo(document("deleteAuctioneer",
+				requestHeaders(
+					headerWithName("X-AUTH-TOKEN").description(
+						"토큰값")),
+				responseFields(
+					fieldWithPath("success").description("성공여부"),
+					fieldWithPath("code").description("코드번호"),
+					fieldWithPath("msg").description("메시지"),
+					fieldWithPath("data").description("성공/실패")
+
+				)));
 	}
 }

--- a/auction/src/test/java/kr/or/dining_together/auction/controller/AuctioneerControllerTest.java
+++ b/auction/src/test/java/kr/or/dining_together/auction/controller/AuctioneerControllerTest.java
@@ -1,0 +1,109 @@
+package kr.or.dining_together.auction.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Date;
+
+import javax.transaction.Transactional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import kr.or.dining_together.auction.client.UserServiceClient;
+import kr.or.dining_together.auction.dto.UserIdDto;
+import kr.or.dining_together.auction.jpa.entity.Auction;
+import kr.or.dining_together.auction.jpa.entity.Auctioneer;
+import kr.or.dining_together.auction.jpa.repo.AuctionRepository;
+import kr.or.dining_together.auction.jpa.repo.AuctioneerRepository;
+import kr.or.dining_together.auction.service.AuctionService;
+import kr.or.dining_together.auction.service.AuctioneerService;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc
+@Transactional
+class AuctioneerControllerTest {
+	@Autowired
+	AuctionRepository auctionRepository;
+
+	@Autowired
+	AuctioneerRepository auctioneerRepository;
+	@Autowired
+	AuctioneerService auctioneerService;
+	@Autowired
+	UserServiceClient userServiceClient;
+	@Autowired
+	ModelMapper modelMapper;
+	@Autowired
+	private ObjectMapper objectMapper;
+	UserIdDto userIdDto;
+	@Autowired
+	private MockMvc mockMvc;
+
+	Auction auction;
+	Auctioneer auctioneer;
+	@BeforeEach
+	void setUp() {
+		userIdDto = UserIdDto.builder()
+			.id(1L)
+			.name("moon")
+			.build();
+
+		System.out.println(userIdDto.getId());
+		Auction auction1 = Auction.builder()
+			.title("제목")
+			.content("내용")
+			.maxPrice(1000)
+			.minPrice(10)
+			.userType("Family")
+			.userId(1L)
+			.reservation(new Date())
+			.deadline(new Date())
+			.build();
+
+		auction=auctionRepository.save(auction1);
+
+		Auctioneer auctioneer1=Auctioneer.builder()
+			.menu("menu")
+			.auction(auction)
+			.content("content")
+			.price(1)
+			.storeId(1L)
+			.build();
+
+		auctioneer=auctioneerRepository.save(auctioneer1);
+	}
+
+	@Test
+	void auctioneers() {
+
+	}
+
+	@Test
+	void registerAuctioneer() {
+	}
+
+	@Test
+	void modifyAuction() {
+	}
+
+	@Test
+	void deleteAuction() {
+	}
+}

--- a/auction/src/test/java/kr/or/dining_together/auction/service/AuctionServiceTest.java
+++ b/auction/src/test/java/kr/or/dining_together/auction/service/AuctionServiceTest.java
@@ -14,7 +14,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import kr.or.dining_together.auction.client.UserServiceClient;
-import kr.or.dining_together.auction.dto.AuctionDto;
 import kr.or.dining_together.auction.dto.UserIdDto;
 import kr.or.dining_together.auction.jpa.entity.Auction;
 import kr.or.dining_together.auction.jpa.repo.AuctionRepository;

--- a/auction/src/test/java/kr/or/dining_together/auction/service/AuctionServiceTest.java
+++ b/auction/src/test/java/kr/or/dining_together/auction/service/AuctionServiceTest.java
@@ -13,9 +13,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import kr.or.dining_together.auction.client.UserServiceClient;
 import kr.or.dining_together.auction.dto.AuctionDto;
+import kr.or.dining_together.auction.dto.UserIdDto;
 import kr.or.dining_together.auction.jpa.entity.Auction;
 import kr.or.dining_together.auction.jpa.repo.AuctionRepository;
+import kr.or.dining_together.auction.vo.RequestAuction;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -28,18 +31,28 @@ class AuctionServiceTest {
 	AuctionService auctionService;
 
 	@Autowired
+	UserServiceClient userServiceClient;
+
+	@Autowired
 	ModelMapper modelMapper;
 
 	Auction auction;
 
+	UserIdDto userIdDto;
+
 	@BeforeEach
 	void setUp() {
+
+		userIdDto = UserIdDto.builder()
+			.id("1")
+			.name("moon")
+			.build();
+
 		auction = Auction.builder()
-			.auctionId(1L)
 			.title("제목")
 			.content("내용")
-			.maxPrice("1000")
-			.minPrice("10")
+			.maxPrice(1000)
+			.minPrice(10)
 			.userType("Family")
 			.userId("1")
 			.reservation(new Date())
@@ -60,7 +73,7 @@ class AuctionServiceTest {
 
 	@Test
 	void getAuction() {
-		long auctionId = 1L;
+		long auctionId = auction.getAuctionId();
 		Auction auction2 = auctionService.getAuction(auctionId);
 
 		assertEquals(auction.getAuctionId(), auction2.getAuctionId());
@@ -77,65 +90,45 @@ class AuctionServiceTest {
 
 	@Test
 	void writeAuction() {
-
-		long auctionId = 2L;
-		Auction auction = Auction.builder()
-			.auctionId(2L)
+		RequestAuction auction1 = RequestAuction.builder()
 			.title("제목2")
 			.content("내용2")
-			.maxPrice("2000")
-			.minPrice("20")
+			.maxPrice(2000)
+			.minPrice(20)
 			.userType("Friend")
-			.userId("2")
 			.reservation(new Date())
 			.deadline(new Date())
 			.build();
 
-		AuctionDto auctionDto = modelMapper.map(auction, AuctionDto.class);
+		Auction auction = auctionService.writeAuction(userIdDto, auction1);
 
-		assertEquals(auctionRepository.findById(auctionId).get().getAuctionId(), auction.getAuctionId());
+		assertEquals(auction.getTitle(), "제목2");
 
 	}
 
 	@Test
 	void updateAuction() {
-		long auctionId = 1L;
 
-		Auction auction = Auction.builder()
-			.auctionId(1L)
+		Auction modifyAuction = Auction.builder()
 			.title("제목1")
 			.content("내용2")
-			.maxPrice("2000")
-			.minPrice("20")
+			.maxPrice(2000)
+			.minPrice(20)
 			.userType("Friend")
 			.reservation(new Date())
 			.deadline(new Date())
 			.build();
 
-		AuctionDto auctionDto = modelMapper.map(auction, AuctionDto.class);
+		AuctionDto auctionDto = modelMapper.map(modifyAuction, AuctionDto.class);
 
-		auctionService.updateAuction(auction.getAuctionId(), auctionDto);
+		Auction auction1 = auctionService.updateAuction(auction.getAuctionId(), auctionDto);
 
-		assertEquals(auctionRepository.findById(auctionId).get().getTitle(), "제목1");
+		assertEquals(auction1.getTitle(), "제목1");
 
 	}
 
 	@Test
 	void deleteAuction() {
-		long auctionId = 3L;
-		Auction auction = Auction.builder()
-			.auctionId(3L)
-			.title("제목2")
-			.content("내용2")
-			.maxPrice("2000")
-			.minPrice("20")
-			.userType("Friend")
-			.reservation(new Date())
-			.deadline(new Date())
-			.build();
-
-		auctionRepository.save(auction);
-
 		auctionService.deleteAuction(auction.getAuctionId());
 
 		assertTrue(auctionRepository.findById(auction.getAuctionId()).isEmpty());

--- a/auction/src/test/java/kr/or/dining_together/auction/service/AuctionServiceTest.java
+++ b/auction/src/test/java/kr/or/dining_together/auction/service/AuctionServiceTest.java
@@ -44,7 +44,7 @@ class AuctionServiceTest {
 	void setUp() {
 
 		userIdDto = UserIdDto.builder()
-			.id("1")
+			.id(1L)
 			.name("moon")
 			.build();
 
@@ -54,7 +54,7 @@ class AuctionServiceTest {
 			.maxPrice(1000)
 			.minPrice(10)
 			.userType("Family")
-			.userId("1")
+			.userId(1L)
 			.reservation(new Date())
 			.deadline(new Date())
 			.build();
@@ -81,7 +81,7 @@ class AuctionServiceTest {
 
 	@Test
 	void getAuctionsByUserId() {
-		String userId = "1";
+		long userId = 1L;
 		List<Auction> auctions = auctionService.getAuctionsByUserId(userId);
 
 		assertEquals(auctions.get(0).getUserId(), userId);
@@ -119,9 +119,9 @@ class AuctionServiceTest {
 			.deadline(new Date())
 			.build();
 
-		AuctionDto auctionDto = modelMapper.map(modifyAuction, AuctionDto.class);
+		RequestAuction requestAuction = modelMapper.map(modifyAuction, RequestAuction.class);
 
-		Auction auction1 = auctionService.updateAuction(auction.getAuctionId(), auctionDto);
+		Auction auction1 = auctionService.updateAuction(auction.getAuctionId(), requestAuction);
 
 		assertEquals(auction1.getTitle(), "제목1");
 

--- a/auction/src/test/java/kr/or/dining_together/auction/service/AuctioneerServiceTest.java
+++ b/auction/src/test/java/kr/or/dining_together/auction/service/AuctioneerServiceTest.java
@@ -47,7 +47,7 @@ class AuctioneerServiceTest {
 	@BeforeEach
 	void setUp() {
 		userIdDto = UserIdDto.builder()
-			.id("1")
+			.id(1L)
 			.name("moon")
 			.build();
 
@@ -57,7 +57,7 @@ class AuctioneerServiceTest {
 			.deadline(new Date())
 			.maxPrice(10)
 			.minPrice(0)
-			.userId("1")
+			.userId(1L)
 			.userType("회식")
 			.reservation(new Date())
 			.build();
@@ -69,7 +69,7 @@ class AuctioneerServiceTest {
 			.auction(auction)
 			.price(10000)
 			.menu("메뉴")
-			.storeId("1")
+			.storeId(1L)
 			.build();
 
 		auctioneer = auctioneerRepository.save(auctioneer1);
@@ -77,7 +77,7 @@ class AuctioneerServiceTest {
 
 	@Test
 	void getAuctioneer() {
-		List<Auctioneer> auctioneers = auctioneerService.getAuctioneer(auction.getAuctionId());
+		List<Auctioneer> auctioneers = auctioneerService.getAuctioneers(auction.getAuctionId());
 		assertFalse(auctioneers.isEmpty());
 	}
 

--- a/auction/src/test/java/kr/or/dining_together/auction/service/AuctioneerServiceTest.java
+++ b/auction/src/test/java/kr/or/dining_together/auction/service/AuctioneerServiceTest.java
@@ -1,16 +1,15 @@
 package kr.or.dining_together.auction.service;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.util.Date;
 import java.util.List;
-import static org.junit.jupiter.api.Assertions.*;
-import javax.transaction.Transactional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.stereotype.Service;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import kr.or.dining_together.auction.dto.UserIdDto;
@@ -19,7 +18,6 @@ import kr.or.dining_together.auction.jpa.entity.Auctioneer;
 import kr.or.dining_together.auction.jpa.repo.AuctionRepository;
 import kr.or.dining_together.auction.jpa.repo.AuctioneerRepository;
 import kr.or.dining_together.auction.vo.AuctioneerRequest;
-import lombok.RequiredArgsConstructor;
 
 /**
  * @package : kr.or.dining_together.auction.service
@@ -64,7 +62,7 @@ class AuctioneerServiceTest {
 			.reservation(new Date())
 			.build();
 
-		auction=auctionRepository.save(auction1);
+		auction = auctionRepository.save(auction1);
 
 		Auctioneer auctioneer1 = Auctioneer.builder()
 			.content("우리 업체는~")
@@ -74,12 +72,12 @@ class AuctioneerServiceTest {
 			.storeId("1")
 			.build();
 
-		auctioneer= auctioneerRepository.save(auctioneer1);
+		auctioneer = auctioneerRepository.save(auctioneer1);
 	}
 
 	@Test
 	void getAuctioneer() {
-		List<Auctioneer> auctioneers=auctioneerService.getAuctioneer(auction.getAuctionId());
+		List<Auctioneer> auctioneers = auctioneerService.getAuctioneer(auction.getAuctionId());
 		assertFalse(auctioneers.isEmpty());
 	}
 
@@ -91,10 +89,10 @@ class AuctioneerServiceTest {
 			.price(10)
 			.build();
 
-		Auctioneer auctioneer= auctioneerService.registerAuctioneer(auctioneerRequest,userIdDto,auction.getAuctionId());
+		Auctioneer auctioneer = auctioneerService.registerAuctioneer(auctioneerRequest, userIdDto,
+			auction.getAuctionId());
 
-		assertEquals(auctioneer.getContent(),"content");
-
+		assertEquals(auctioneer.getContent(), "content");
 
 	}
 
@@ -106,10 +104,9 @@ class AuctioneerServiceTest {
 			.price(101)
 			.build();
 
-		Auctioneer auctioneer1= auctioneerService.modifyAuctioneer(auctioneerRequest,auctioneer.getAuctioneerId());
+		Auctioneer auctioneer1 = auctioneerService.modifyAuctioneer(auctioneerRequest, auctioneer.getAuctioneerId());
 
-		assertEquals(auctioneer1.getContent(),"content1");
-
+		assertEquals(auctioneer1.getContent(), "content1");
 
 	}
 

--- a/auction/src/test/java/kr/or/dining_together/auction/service/AuctioneerServiceTest.java
+++ b/auction/src/test/java/kr/or/dining_together/auction/service/AuctioneerServiceTest.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import kr.or.dining_together.auction.dto.AuctioneerDto;
 import kr.or.dining_together.auction.dto.UserIdDto;
 import kr.or.dining_together.auction.jpa.entity.Auction;
 import kr.or.dining_together.auction.jpa.entity.Auctioneer;
@@ -89,7 +90,7 @@ class AuctioneerServiceTest {
 			.price(10)
 			.build();
 
-		Auctioneer auctioneer = auctioneerService.registerAuctioneer(auctioneerRequest, userIdDto,
+		AuctioneerDto auctioneer = auctioneerService.registerAuctioneer(auctioneerRequest, userIdDto,
 			auction.getAuctionId());
 
 		assertEquals(auctioneer.getContent(), "content");
@@ -104,7 +105,7 @@ class AuctioneerServiceTest {
 			.price(101)
 			.build();
 
-		Auctioneer auctioneer1 = auctioneerService.modifyAuctioneer(auctioneerRequest, auctioneer.getAuctioneerId());
+		AuctioneerDto auctioneer1 = auctioneerService.modifyAuctioneer(auctioneerRequest, auctioneer.getAuctioneerId());
 
 		assertEquals(auctioneer1.getContent(), "content1");
 

--- a/auction/src/test/java/kr/or/dining_together/auction/service/AuctioneerServiceTest.java
+++ b/auction/src/test/java/kr/or/dining_together/auction/service/AuctioneerServiceTest.java
@@ -1,0 +1,121 @@
+package kr.or.dining_together.auction.service;
+
+import java.util.Date;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.*;
+import javax.transaction.Transactional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.stereotype.Service;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import kr.or.dining_together.auction.dto.UserIdDto;
+import kr.or.dining_together.auction.jpa.entity.Auction;
+import kr.or.dining_together.auction.jpa.entity.Auctioneer;
+import kr.or.dining_together.auction.jpa.repo.AuctionRepository;
+import kr.or.dining_together.auction.jpa.repo.AuctioneerRepository;
+import kr.or.dining_together.auction.vo.AuctioneerRequest;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @package : kr.or.dining_together.auction.service
+ * @name: AuctioneerServiceTest.java
+ * @date : 2021/06/16 9:05 오후
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description :
+ * @modified :
+ **/
+@RunWith(SpringRunner.class)
+@SpringBootTest
+class AuctioneerServiceTest {
+	@Autowired
+	AuctioneerRepository auctioneerRepository;
+	@Autowired
+	AuctionRepository auctionRepository;
+	@Autowired
+	AuctioneerService auctioneerService;
+
+	Auction auction;
+
+	Auctioneer auctioneer;
+
+	UserIdDto userIdDto;
+
+	@BeforeEach
+	void setUp() {
+		userIdDto = UserIdDto.builder()
+			.id("1")
+			.name("moon")
+			.build();
+
+		Auction auction1 = Auction.builder()
+			.content("내용")
+			.title("공고임")
+			.deadline(new Date())
+			.maxPrice(10)
+			.minPrice(0)
+			.userId("1")
+			.userType("회식")
+			.reservation(new Date())
+			.build();
+
+		auction=auctionRepository.save(auction1);
+
+		Auctioneer auctioneer1 = Auctioneer.builder()
+			.content("우리 업체는~")
+			.auction(auction)
+			.price(10000)
+			.menu("메뉴")
+			.storeId("1")
+			.build();
+
+		auctioneer= auctioneerRepository.save(auctioneer1);
+	}
+
+	@Test
+	void getAuctioneer() {
+		List<Auctioneer> auctioneers=auctioneerService.getAuctioneer(auction.getAuctionId());
+		assertFalse(auctioneers.isEmpty());
+	}
+
+	@Test
+	void registerAuctioneer() {
+		AuctioneerRequest auctioneerRequest = AuctioneerRequest.builder()
+			.content("content")
+			.menu("menu")
+			.price(10)
+			.build();
+
+		Auctioneer auctioneer= auctioneerService.registerAuctioneer(auctioneerRequest,userIdDto,auction.getAuctionId());
+
+		assertEquals(auctioneer.getContent(),"content");
+
+
+	}
+
+	@Test
+	void modifyAuctioneer() {
+		AuctioneerRequest auctioneerRequest = AuctioneerRequest.builder()
+			.content("content1")
+			.menu("menu1")
+			.price(101)
+			.build();
+
+		Auctioneer auctioneer1= auctioneerService.modifyAuctioneer(auctioneerRequest,auctioneer.getAuctioneerId());
+
+		assertEquals(auctioneer1.getContent(),"content1");
+
+
+	}
+
+	@Test
+	void deleteAuctioneer() {
+		auctioneerService.deleteAuctioneer(auctioneer.getAuctioneerId());
+		assertTrue(auctioneerRepository.findById(auctioneer.getAuctioneerId()).isEmpty());
+	}
+}

--- a/member/docs/api.json
+++ b/member/docs/api.json
@@ -1,34 +1,40 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "member",
-    "description": "Demo project for Spring Boot",
-    "version": "0.0.1-SNAPSHOT"
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "member",
+    "description" : "Demo project for Spring Boot",
+    "version" : "0.0.1-SNAPSHOT"
   },
-  "servers": [
-    {
-      "url": "http://localhost"
-    }
-  ],
-  "tags": [],
-  "paths": {
-    "/member/customer": {
-      "get": {
-        "tags": [
-          "member"
-        ],
-        "operationId": "getCustomer",
-        "responses": {
-          "200": {
-            "description": "200",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/member-customer-48225865"
+  "servers" : [ {
+    "url" : "http://localhost"
+  } ],
+  "tags" : [ ],
+  "paths" : {
+    "/member/customer" : {
+      "get" : {
+        "tags" : [ "member" ],
+        "operationId" : "getCustomer",
+        "parameters" : [ {
+          "name" : "X-AUTH-TOKEN",
+          "in" : "header",
+          "description" : "토큰값",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJqaWZyb3plbkBuYXZlci5jb20iLCJyb2xlcyI6WyJST0xFX1VTRVIiXSwiaWF0IjoxNjI0NDI3Nzk1LCJleHAiOjE2MjQ1MTQxOTV9.KAYFpOEGHoQThJ_S2NojihUcY1On1JCo3SsQDiey0dc"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/member-customer-48225865"
                 },
-                "examples": {
-                  "getCustomer": {
-                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":{\"createdDate\":\"2021-06-21T05:42:18.690+00:00\",\"updatedDate\":\"2021-06-21T05:42:18.690+00:00\",\"id\":1,\"email\":\"jifrozen@naver.com\",\"name\":\"문지언\",\"joinDate\":\"2021-06-21T05:42:18.690+00:00\",\"provider\":null,\"roles\":[\"ROLE_USER\"],\"age\":0,\"gender\":null,\"authorities\":[{\"authority\":\"ROLE_USER\"}]}}"
+                "examples" : {
+                  "getCustomer" : {
+                    "value" : "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":{\"createdDate\":\"2021-06-23T05:56:35.601+00:00\",\"updatedDate\":\"2021-06-23T05:56:35.601+00:00\",\"id\":1,\"email\":\"jifrozen@naver.com\",\"name\":\"문지언\",\"joinDate\":\"2021-06-23T05:56:35.601+00:00\",\"provider\":null,\"roles\":[\"ROLE_USER\"],\"age\":0,\"gender\":null,\"authorities\":[{\"authority\":\"ROLE_USER\"}]}}"
                   }
                 }
               }
@@ -36,36 +42,44 @@
           }
         }
       },
-      "put": {
-        "tags": [
-          "member"
-        ],
-        "operationId": "modifyCustomer",
-        "requestBody": {
-          "content": {
-            "application/json;charset=UTF-8": {
-              "schema": {
-                "$ref": "#/components/schemas/member-customer-885429557"
+      "put" : {
+        "tags" : [ "member" ],
+        "operationId" : "modifyCustomer",
+        "parameters" : [ {
+          "name" : "X-AUTH-TOKEN",
+          "in" : "header",
+          "description" : "토큰값",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJqaWZyb3plbkBuYXZlci5jb20iLCJyb2xlcyI6WyJST0xFX1VTRVIiXSwiaWF0IjoxNjI0NDI3Nzk3LCJleHAiOjE2MjQ1MTQxOTd9.ix2vrI7omdLe_NHcPGq0Td57DETFOjg7NgIIbUbYDM4"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json;charset=UTF-8" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/member-customer-885429557"
               },
-              "examples": {
-                "modifyCustomer": {
-                  "value": "{\"password\":\"test1111\",\"name\":\"test11\",\"age\":1,\"gender\":\"male\"}"
+              "examples" : {
+                "modifyCustomer" : {
+                  "value" : "{\"password\":\"test1111\",\"name\":\"test11\",\"age\":1,\"gender\":\"male\"}"
                 }
               }
             }
           }
         },
-        "responses": {
-          "200": {
-            "description": "200",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/member-customer-1499051551"
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/member-customer-1499051551"
                 },
-                "examples": {
-                  "modifyCustomer": {
-                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":{\"email\":\"jifrozen@naver.com\",\"password\":null,\"name\":\"test11\",\"age\":1,\"gender\":\"male\"}}"
+                "examples" : {
+                  "modifyCustomer" : {
+                    "value" : "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":{\"email\":\"jifrozen@naver.com\",\"password\":null,\"name\":\"test11\",\"age\":1,\"gender\":\"male\"}}"
                   }
                 }
               }
@@ -74,23 +88,31 @@
         }
       }
     },
-    "/member/store": {
-      "get": {
-        "tags": [
-          "member"
-        ],
-        "operationId": "getStore",
-        "responses": {
-          "200": {
-            "description": "200",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/member-store-297999565"
+    "/member/store" : {
+      "get" : {
+        "tags" : [ "member" ],
+        "operationId" : "getStore",
+        "parameters" : [ {
+          "name" : "X-AUTH-TOKEN",
+          "in" : "header",
+          "description" : "토큰값",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJqaWZyb3plbjFAbmF2ZXIuY29tIiwicm9sZXMiOlsiUk9MRV9VU0VSIl0sImlhdCI6MTYyNDQyNzc5OCwiZXhwIjoxNjI0NTE0MTk4fQ.mmfVnSv4WXZofXAvvoJ4EGibcJ9xED_LlrhmaRCGOps"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/member-store-297999565"
                 },
-                "examples": {
-                  "getStore": {
-                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":{\"createdDate\":\"2021-06-21T05:42:21.544+00:00\",\"updatedDate\":\"2021-06-21T05:42:21.546+00:00\",\"id\":12,\"email\":\"jifrozen1@naver.com\",\"name\":\"문지언\",\"joinDate\":\"2021-06-21T05:42:21.544+00:00\",\"provider\":null,\"roles\":[\"ROLE_USER\"],\"documentChecked\":null,\"menus\":null,\"authorities\":[{\"authority\":\"ROLE_USER\"}]}}"
+                "examples" : {
+                  "getStore" : {
+                    "value" : "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":{\"createdDate\":\"2021-06-23T05:56:38.428+00:00\",\"updatedDate\":\"2021-06-23T05:56:38.431+00:00\",\"id\":12,\"email\":\"jifrozen1@naver.com\",\"name\":\"문지언\",\"joinDate\":\"2021-06-23T05:56:38.428+00:00\",\"provider\":null,\"roles\":[\"ROLE_USER\"],\"documentChecked\":null,\"menus\":null,\"authorities\":[{\"authority\":\"ROLE_USER\"}]}}"
                   }
                 }
               }
@@ -98,36 +120,44 @@
           }
         }
       },
-      "put": {
-        "tags": [
-          "member"
-        ],
-        "operationId": "modifyStore",
-        "requestBody": {
-          "content": {
-            "application/json;charset=UTF-8": {
-              "schema": {
-                "$ref": "#/components/schemas/member-store-1038572502"
+      "put" : {
+        "tags" : [ "member" ],
+        "operationId" : "modifyStore",
+        "parameters" : [ {
+          "name" : "X-AUTH-TOKEN",
+          "in" : "header",
+          "description" : "토큰값",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJqaWZyb3plbkBuYXZlci5jb20iLCJyb2xlcyI6WyJST0xFX1VTRVIiXSwiaWF0IjoxNjI0NDI3Nzk3LCJleHAiOjE2MjQ1MTQxOTd9.ix2vrI7omdLe_NHcPGq0Td57DETFOjg7NgIIbUbYDM4"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json;charset=UTF-8" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/member-store-1038572502"
               },
-              "examples": {
-                "modifyStore": {
-                  "value": "{\"password\":\"test1111\",\"name\":\"test11\"}"
+              "examples" : {
+                "modifyStore" : {
+                  "value" : "{\"password\":\"test1111\",\"name\":\"test11\"}"
                 }
               }
             }
           }
         },
-        "responses": {
-          "200": {
-            "description": "200",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/member-store2134880610"
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/member-store2134880610"
                 },
-                "examples": {
-                  "modifyStore": {
-                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":{\"email\":\"jifrozen@naver.com\",\"password\":null,\"name\":\"test11\"}}"
+                "examples" : {
+                  "modifyStore" : {
+                    "value" : "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":{\"email\":\"jifrozen@naver.com\",\"password\":null,\"name\":\"test11\"}}"
                   }
                 }
               }
@@ -136,23 +166,31 @@
         }
       }
     },
-    "/member/user": {
-      "delete": {
-        "tags": [
-          "member"
-        ],
-        "operationId": "delete",
-        "responses": {
-          "200": {
-            "description": "200",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/member-auth-signup1010847454"
+    "/member/user" : {
+      "delete" : {
+        "tags" : [ "member" ],
+        "operationId" : "delete",
+        "parameters" : [ {
+          "name" : "X-AUTH-TOKEN",
+          "in" : "header",
+          "description" : "토큰값",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJqaWZyb3plbkBuYXZlci5jb20iLCJyb2xlcyI6WyJST0xFX1VTRVIiXSwiaWF0IjoxNjI0NDI3Nzk2LCJleHAiOjE2MjQ1MTQxOTZ9.uuUEX7xVswuGJmqGKaTmWU-y58GrBbhLIGPTz60xYa0"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/member-auth-signup1010847454"
                 },
-                "examples": {
-                  "delete": {
-                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\"}"
+                "examples" : {
+                  "delete" : {
+                    "value" : "{\"success\":true,\"code\":0,\"msg\":\"성공\"}"
                   }
                 }
               }
@@ -161,23 +199,21 @@
         }
       }
     },
-    "/member/userId": {
-      "get": {
-        "tags": [
-          "member"
-        ],
-        "operationId": "getUserId",
-        "responses": {
-          "200": {
-            "description": "200",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/member-userId-1032691858"
+    "/member/userId" : {
+      "get" : {
+        "tags" : [ "member" ],
+        "operationId" : "getUserId",
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/member-userId-1032691858"
                 },
-                "examples": {
-                  "getUserId": {
-                    "value": "{\"id\":8,\"name\":\"문지언\"}"
+                "examples" : {
+                  "getUserId" : {
+                    "value" : "{\"id\":8,\"name\":\"문지언\"}"
                   }
                 }
               }
@@ -186,37 +222,35 @@
         }
       }
     },
-    "/member/auth/signin": {
-      "post": {
-        "tags": [
-          "member"
-        ],
-        "operationId": "login",
-        "requestBody": {
-          "content": {
-            "application/json;charset=UTF-8": {
-              "schema": {
-                "$ref": "#/components/schemas/member-auth-signin278934565"
+    "/member/auth/signin" : {
+      "post" : {
+        "tags" : [ "member" ],
+        "operationId" : "login",
+        "requestBody" : {
+          "content" : {
+            "application/json;charset=UTF-8" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/member-auth-signin278934565"
               },
-              "examples": {
-                "login": {
-                  "value": "{\"email\":\"jifrozen@naver.com\",\"password\":\"test1111\"}"
+              "examples" : {
+                "login" : {
+                  "value" : "{\"email\":\"jifrozen@naver.com\",\"password\":\"test1111\"}"
                 }
               }
             }
           }
         },
-        "responses": {
-          "200": {
-            "description": "200",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/member-auth-signin-1190539043"
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/member-auth-signin-1190539043"
                 },
-                "examples": {
-                  "login": {
-                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":\"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJqaWZyb3plbkBuYXZlci5jb20iLCJyb2xlcyI6WyJST0xFX1VTRVIiXSwiaWF0IjoxNjI0MjU0MTYyLCJleHAiOjE2MjQzNDA1NjJ9.2j2omlWe6F60BXATrmw2qOoTBH-Ffou0vzu_gaCzXC4\"}"
+                "examples" : {
+                  "login" : {
+                    "value" : "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":\"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJqaWZyb3plbkBuYXZlci5jb20iLCJyb2xlcyI6WyJST0xFX1VTRVIiXSwiaWF0IjoxNjI0MzU2MzkzLCJleHAiOjE2MjQ0NDI3OTN9.C6Lu9EykUGKJpTiJ9vndNyDYThvWOVJuoSf_S9JGgpw\"}"
                   }
                 }
               }
@@ -225,37 +259,35 @@
         }
       }
     },
-    "/member/auth/signup": {
-      "post": {
-        "tags": [
-          "member"
-        ],
-        "operationId": "signup",
-        "requestBody": {
-          "content": {
-            "application/json;charset=UTF-8": {
-              "schema": {
-                "$ref": "#/components/schemas/member-auth-signup1306409953"
+    "/member/auth/signup" : {
+      "post" : {
+        "tags" : [ "member" ],
+        "operationId" : "signup",
+        "requestBody" : {
+          "content" : {
+            "application/json;charset=UTF-8" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/member-auth-signup1306409953"
               },
-              "examples": {
-                "signup": {
-                  "value": "{\"email\":\"jifrozen1@naver.com\",\"name\":\"문지언1\",\"password\":\"test2222\",\"userType\":\"CUSTOMER\",\"age\":23,\"gender\":\"FEMALE\"}"
+              "examples" : {
+                "signup" : {
+                  "value" : "{\"email\":\"jifrozen1@naver.com\",\"name\":\"문지언1\",\"password\":\"test2222\",\"userType\":\"CUSTOMER\",\"age\":23,\"gender\":\"FEMALE\"}"
                 }
               }
             }
           }
         },
-        "responses": {
-          "200": {
-            "description": "200",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/member-auth-signup1010847454"
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/member-auth-signup1010847454"
                 },
-                "examples": {
-                  "signup": {
-                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\"}"
+                "examples" : {
+                  "signup" : {
+                    "value" : "{\"success\":true,\"code\":0,\"msg\":\"성공\"}"
                   }
                 }
               }
@@ -265,360 +297,350 @@
       }
     }
   },
-  "components": {
-    "schemas": {
-      "member-customer-885429557": {
-        "type": "object",
-        "properties": {
-          "password": {
-            "type": "string",
-            "description": "유저 비밀번호"
+  "components" : {
+    "schemas" : {
+      "member-store-1038572502" : {
+        "type" : "object",
+        "properties" : {
+          "password" : {
+            "type" : "string",
+            "description" : "유저 비밀번호"
           },
-          "gender": {
-            "type": "string",
-            "description": "사용자 성별"
-          },
-          "name": {
-            "type": "string",
-            "description": "사용자 이름"
-          },
-          "age": {
-            "type": "number",
-            "description": "사용자 나이"
+          "name" : {
+            "type" : "string",
+            "description" : "사용자 이름"
           }
         }
       },
-      "member-store-1038572502": {
-        "type": "object",
-        "properties": {
-          "password": {
-            "type": "string",
-            "description": "유저 비밀번호"
+      "member-customer-885429557" : {
+        "type" : "object",
+        "properties" : {
+          "password" : {
+            "type" : "string",
+            "description" : "유저 비밀번호"
           },
-          "name": {
-            "type": "string",
-            "description": "사용자 이름"
+          "gender" : {
+            "type" : "string",
+            "description" : "사용자 성별"
+          },
+          "name" : {
+            "type" : "string",
+            "description" : "사용자 이름"
+          },
+          "age" : {
+            "type" : "number",
+            "description" : "사용자 나이"
           }
         }
       },
-      "member-auth-signin-1190539043": {
-        "type": "object",
-        "properties": {
-          "msg": {
-            "type": "string",
-            "description": "메시지"
+      "member-auth-signin-1190539043" : {
+        "type" : "object",
+        "properties" : {
+          "msg" : {
+            "type" : "string",
+            "description" : "메시지"
           },
-          "code": {
-            "type": "number",
-            "description": "코드번호"
+          "code" : {
+            "type" : "number",
+            "description" : "코드번호"
           },
-          "data": {
-            "type": "string",
-            "description": "토큰값"
+          "data" : {
+            "type" : "string",
+            "description" : "토큰값"
           },
-          "success": {
-            "type": "boolean",
-            "description": "성공여부"
+          "success" : {
+            "type" : "boolean",
+            "description" : "성공여부"
           }
         }
       },
-      "member-auth-signin278934565": {
-        "type": "object",
-        "properties": {
-          "password": {
-            "type": "string",
-            "description": "유저 비밀번호"
+      "member-auth-signin278934565" : {
+        "type" : "object",
+        "properties" : {
+          "password" : {
+            "type" : "string",
+            "description" : "유저 비밀번호"
           },
-          "email": {
-            "type": "string",
-            "description": "유저 아이디(이메일)"
+          "email" : {
+            "type" : "string",
+            "description" : "유저 아이디(이메일)"
           }
         }
       },
-      "member-customer-1499051551": {
-        "type": "object",
-        "properties": {
-          "msg": {
-            "type": "string",
-            "description": "메시지"
+      "member-customer-48225865" : {
+        "type" : "object",
+        "properties" : {
+          "msg" : {
+            "type" : "string",
+            "description" : "메시지"
           },
-          "code": {
-            "type": "number",
-            "description": "코드번호"
+          "code" : {
+            "type" : "number",
+            "description" : "코드번호"
           },
-          "data": {
-            "type": "object",
-            "properties": {
-              "gender": {
-                "type": "string",
-                "description": "사용자 성별"
+          "data" : {
+            "type" : "object",
+            "properties" : {
+              "joinDate" : {
+                "type" : "string",
+                "description" : "사용자 가입일자"
               },
-              "name": {
-                "type": "string",
-                "description": "사용자 이름"
+              "createdDate" : {
+                "type" : "string",
+                "description" : "생성일자"
               },
-              "age": {
-                "type": "number",
-                "description": "사용자 나이"
-              },
-              "email": {
-                "type": "string",
-                "description": "사용자 이메일(아이디)"
-              }
-            }
-          },
-          "success": {
-            "type": "boolean",
-            "description": "성공여부"
-          }
-        }
-      },
-      "member-customer-48225865": {
-        "type": "object",
-        "properties": {
-          "msg": {
-            "type": "string",
-            "description": "메시지"
-          },
-          "code": {
-            "type": "number",
-            "description": "코드번호"
-          },
-          "data": {
-            "type": "object",
-            "properties": {
-              "joinDate": {
-                "type": "string",
-                "description": "사용자 가입일자"
-              },
-              "createdDate": {
-                "type": "string",
-                "description": "생성일자"
-              },
-              "roles": {
-                "type": "array",
-                "description": "사용자 타입",
-                "items": {
-                  "oneOf": [
-                    {
-                      "type": "object"
-                    },
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ]
+              "roles" : {
+                "type" : "array",
+                "description" : "사용자 타입",
+                "items" : {
+                  "oneOf" : [ {
+                    "type" : "object"
+                  }, {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string"
+                  }, {
+                    "type" : "number"
+                  } ]
                 }
               },
-              "name": {
-                "type": "string",
-                "description": "사용자 이름"
+              "name" : {
+                "type" : "string",
+                "description" : "사용자 이름"
               },
-              "id": {
-                "type": "number",
-                "description": "사용자 id"
+              "id" : {
+                "type" : "number",
+                "description" : "사용자 id"
               },
-              "updatedDate": {
-                "type": "string",
-                "description": "수정일자"
+              "updatedDate" : {
+                "type" : "string",
+                "description" : "수정일자"
               },
-              "authorities": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "authority": {
-                      "type": "string",
-                      "description": "사용자 권한"
+              "authorities" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "authority" : {
+                      "type" : "string",
+                      "description" : "사용자 권한"
                     }
                   }
                 }
               },
-              "age": {
-                "type": "number",
-                "description": "사용자 나이"
+              "age" : {
+                "type" : "number",
+                "description" : "사용자 나이"
               },
-              "email": {
-                "type": "string",
-                "description": "사용자 이메일(아이디)"
+              "email" : {
+                "type" : "string",
+                "description" : "사용자 이메일(아이디)"
               }
             }
           },
-          "success": {
-            "type": "boolean",
-            "description": "성공여부"
+          "success" : {
+            "type" : "boolean",
+            "description" : "성공여부"
           }
         }
       },
-      "member-userId-1032691858": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "사용자 이름"
+      "member-customer-1499051551" : {
+        "type" : "object",
+        "properties" : {
+          "msg" : {
+            "type" : "string",
+            "description" : "메시지"
           },
-          "id": {
-            "type": "number",
-            "description": "사용자 id"
-          }
-        }
-      },
-      "member-store2134880610": {
-        "type": "object",
-        "properties": {
-          "msg": {
-            "type": "string",
-            "description": "메시지"
+          "code" : {
+            "type" : "number",
+            "description" : "코드번호"
           },
-          "code": {
-            "type": "number",
-            "description": "코드번호"
-          },
-          "data": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string",
-                "description": "사용자 이름"
+          "data" : {
+            "type" : "object",
+            "properties" : {
+              "gender" : {
+                "type" : "string",
+                "description" : "사용자 성별"
               },
-              "email": {
-                "type": "string",
-                "description": "사용자 이메일(아이디)"
+              "name" : {
+                "type" : "string",
+                "description" : "사용자 이름"
+              },
+              "age" : {
+                "type" : "number",
+                "description" : "사용자 나이"
+              },
+              "email" : {
+                "type" : "string",
+                "description" : "사용자 이메일(아이디)"
               }
             }
           },
-          "success": {
-            "type": "boolean",
-            "description": "성공여부"
+          "success" : {
+            "type" : "boolean",
+            "description" : "성공여부"
           }
         }
       },
-      "member-auth-signup1010847454": {
-        "type": "object",
-        "properties": {
-          "msg": {
-            "type": "string",
-            "description": "메시지"
+      "member-userId-1032691858" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "사용자 이름"
           },
-          "code": {
-            "type": "number",
-            "description": "코드번호"
-          },
-          "success": {
-            "type": "boolean",
-            "description": "성공여부"
+          "id" : {
+            "type" : "number",
+            "description" : "사용자 id"
           }
         }
       },
-      "member-auth-signup1306409953": {
-        "type": "object",
-        "properties": {
-          "password": {
-            "type": "string",
-            "description": "유저 비밀번호"
+      "member-store2134880610" : {
+        "type" : "object",
+        "properties" : {
+          "msg" : {
+            "type" : "string",
+            "description" : "메시지"
           },
-          "gender": {
-            "type": "string",
-            "description": "성별"
+          "code" : {
+            "type" : "number",
+            "description" : "코드번호"
           },
-          "name": {
-            "type": "string",
-            "description": "유저 이름"
-          },
-          "userType": {
-            "type": "string",
-            "description": "유저 타입"
-          },
-          "age": {
-            "type": "number",
-            "description": "나이"
-          },
-          "email": {
-            "type": "string",
-            "description": "유저 아이디(이메일)"
-          }
-        }
-      },
-      "member-store-297999565": {
-        "type": "object",
-        "properties": {
-          "msg": {
-            "type": "string",
-            "description": "메시지"
-          },
-          "code": {
-            "type": "number",
-            "description": "코드번호"
-          },
-          "data": {
-            "type": "object",
-            "properties": {
-              "joinDate": {
-                "type": "string",
-                "description": "사용자 가입일자"
+          "data" : {
+            "type" : "object",
+            "properties" : {
+              "name" : {
+                "type" : "string",
+                "description" : "사용자 이름"
               },
-              "createdDate": {
-                "type": "string",
-                "description": "생성일자"
+              "email" : {
+                "type" : "string",
+                "description" : "사용자 이메일(아이디)"
+              }
+            }
+          },
+          "success" : {
+            "type" : "boolean",
+            "description" : "성공여부"
+          }
+        }
+      },
+      "member-auth-signup1010847454" : {
+        "type" : "object",
+        "properties" : {
+          "msg" : {
+            "type" : "string",
+            "description" : "메시지"
+          },
+          "code" : {
+            "type" : "number",
+            "description" : "코드번호"
+          },
+          "success" : {
+            "type" : "boolean",
+            "description" : "성공여부"
+          }
+        }
+      },
+      "member-auth-signup1306409953" : {
+        "type" : "object",
+        "properties" : {
+          "password" : {
+            "type" : "string",
+            "description" : "유저 비밀번호"
+          },
+          "gender" : {
+            "type" : "string",
+            "description" : "성별"
+          },
+          "name" : {
+            "type" : "string",
+            "description" : "유저 이름"
+          },
+          "userType" : {
+            "type" : "string",
+            "description" : "유저 타입"
+          },
+          "age" : {
+            "type" : "number",
+            "description" : "나이"
+          },
+          "email" : {
+            "type" : "string",
+            "description" : "유저 아이디(이메일)"
+          }
+        }
+      },
+      "member-store-297999565" : {
+        "type" : "object",
+        "properties" : {
+          "msg" : {
+            "type" : "string",
+            "description" : "메시지"
+          },
+          "code" : {
+            "type" : "number",
+            "description" : "코드번호"
+          },
+          "data" : {
+            "type" : "object",
+            "properties" : {
+              "joinDate" : {
+                "type" : "string",
+                "description" : "사용자 가입일자"
               },
-              "roles": {
-                "type": "array",
-                "description": "사용자 타입",
-                "items": {
-                  "oneOf": [
-                    {
-                      "type": "object"
-                    },
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ]
+              "createdDate" : {
+                "type" : "string",
+                "description" : "생성일자"
+              },
+              "roles" : {
+                "type" : "array",
+                "description" : "사용자 타입",
+                "items" : {
+                  "oneOf" : [ {
+                    "type" : "object"
+                  }, {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string"
+                  }, {
+                    "type" : "number"
+                  } ]
                 }
               },
-              "name": {
-                "type": "string",
-                "description": "사용자 이름"
+              "name" : {
+                "type" : "string",
+                "description" : "사용자 이름"
               },
-              "id": {
-                "type": "number",
-                "description": "사용자 id"
+              "id" : {
+                "type" : "number",
+                "description" : "사용자 id"
               },
-              "updatedDate": {
-                "type": "string",
-                "description": "수정일자"
+              "updatedDate" : {
+                "type" : "string",
+                "description" : "수정일자"
               },
-              "authorities": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "authority": {
-                      "type": "string",
-                      "description": "사용자 권한"
+              "authorities" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "authority" : {
+                      "type" : "string",
+                      "description" : "사용자 권한"
                     }
                   }
                 }
               },
-              "email": {
-                "type": "string",
-                "description": "사용자 이메일(아이디)"
+              "email" : {
+                "type" : "string",
+                "description" : "사용자 이메일(아이디)"
               }
             }
           },
-          "success": {
-            "type": "boolean",
-            "description": "성공여부"
+          "success" : {
+            "type" : "boolean",
+            "description" : "성공여부"
           }
         }
       }

--- a/member/docs/api.json
+++ b/member/docs/api.json
@@ -1,0 +1,627 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "member",
+    "description": "Demo project for Spring Boot",
+    "version": "0.0.1-SNAPSHOT"
+  },
+  "servers": [
+    {
+      "url": "http://localhost"
+    }
+  ],
+  "tags": [],
+  "paths": {
+    "/member/customer": {
+      "get": {
+        "tags": [
+          "member"
+        ],
+        "operationId": "getCustomer",
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/member-customer-48225865"
+                },
+                "examples": {
+                  "getCustomer": {
+                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":{\"createdDate\":\"2021-06-21T05:42:18.690+00:00\",\"updatedDate\":\"2021-06-21T05:42:18.690+00:00\",\"id\":1,\"email\":\"jifrozen@naver.com\",\"name\":\"문지언\",\"joinDate\":\"2021-06-21T05:42:18.690+00:00\",\"provider\":null,\"roles\":[\"ROLE_USER\"],\"age\":0,\"gender\":null,\"authorities\":[{\"authority\":\"ROLE_USER\"}]}}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "member"
+        ],
+        "operationId": "modifyCustomer",
+        "requestBody": {
+          "content": {
+            "application/json;charset=UTF-8": {
+              "schema": {
+                "$ref": "#/components/schemas/member-customer-885429557"
+              },
+              "examples": {
+                "modifyCustomer": {
+                  "value": "{\"password\":\"test1111\",\"name\":\"test11\",\"age\":1,\"gender\":\"male\"}"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/member-customer-1499051551"
+                },
+                "examples": {
+                  "modifyCustomer": {
+                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":{\"email\":\"jifrozen@naver.com\",\"password\":null,\"name\":\"test11\",\"age\":1,\"gender\":\"male\"}}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/member/store": {
+      "get": {
+        "tags": [
+          "member"
+        ],
+        "operationId": "getStore",
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/member-store-297999565"
+                },
+                "examples": {
+                  "getStore": {
+                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":{\"createdDate\":\"2021-06-21T05:42:21.544+00:00\",\"updatedDate\":\"2021-06-21T05:42:21.546+00:00\",\"id\":12,\"email\":\"jifrozen1@naver.com\",\"name\":\"문지언\",\"joinDate\":\"2021-06-21T05:42:21.544+00:00\",\"provider\":null,\"roles\":[\"ROLE_USER\"],\"documentChecked\":null,\"menus\":null,\"authorities\":[{\"authority\":\"ROLE_USER\"}]}}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "member"
+        ],
+        "operationId": "modifyStore",
+        "requestBody": {
+          "content": {
+            "application/json;charset=UTF-8": {
+              "schema": {
+                "$ref": "#/components/schemas/member-store-1038572502"
+              },
+              "examples": {
+                "modifyStore": {
+                  "value": "{\"password\":\"test1111\",\"name\":\"test11\"}"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/member-store2134880610"
+                },
+                "examples": {
+                  "modifyStore": {
+                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":{\"email\":\"jifrozen@naver.com\",\"password\":null,\"name\":\"test11\"}}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/member/user": {
+      "delete": {
+        "tags": [
+          "member"
+        ],
+        "operationId": "delete",
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/member-auth-signup1010847454"
+                },
+                "examples": {
+                  "delete": {
+                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\"}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/member/userId": {
+      "get": {
+        "tags": [
+          "member"
+        ],
+        "operationId": "getUserId",
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/member-userId-1032691858"
+                },
+                "examples": {
+                  "getUserId": {
+                    "value": "{\"id\":8,\"name\":\"문지언\"}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/member/auth/signin": {
+      "post": {
+        "tags": [
+          "member"
+        ],
+        "operationId": "login",
+        "requestBody": {
+          "content": {
+            "application/json;charset=UTF-8": {
+              "schema": {
+                "$ref": "#/components/schemas/member-auth-signin278934565"
+              },
+              "examples": {
+                "login": {
+                  "value": "{\"email\":\"jifrozen@naver.com\",\"password\":\"test1111\"}"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/member-auth-signin-1190539043"
+                },
+                "examples": {
+                  "login": {
+                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":\"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJqaWZyb3plbkBuYXZlci5jb20iLCJyb2xlcyI6WyJST0xFX1VTRVIiXSwiaWF0IjoxNjI0MjU0MTYyLCJleHAiOjE2MjQzNDA1NjJ9.2j2omlWe6F60BXATrmw2qOoTBH-Ffou0vzu_gaCzXC4\"}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/member/auth/signup": {
+      "post": {
+        "tags": [
+          "member"
+        ],
+        "operationId": "signup",
+        "requestBody": {
+          "content": {
+            "application/json;charset=UTF-8": {
+              "schema": {
+                "$ref": "#/components/schemas/member-auth-signup1306409953"
+              },
+              "examples": {
+                "signup": {
+                  "value": "{\"email\":\"jifrozen1@naver.com\",\"name\":\"문지언1\",\"password\":\"test2222\",\"userType\":\"CUSTOMER\",\"age\":23,\"gender\":\"FEMALE\"}"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/member-auth-signup1010847454"
+                },
+                "examples": {
+                  "signup": {
+                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\"}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "member-customer-885429557": {
+        "type": "object",
+        "properties": {
+          "password": {
+            "type": "string",
+            "description": "유저 비밀번호"
+          },
+          "gender": {
+            "type": "string",
+            "description": "사용자 성별"
+          },
+          "name": {
+            "type": "string",
+            "description": "사용자 이름"
+          },
+          "age": {
+            "type": "number",
+            "description": "사용자 나이"
+          }
+        }
+      },
+      "member-store-1038572502": {
+        "type": "object",
+        "properties": {
+          "password": {
+            "type": "string",
+            "description": "유저 비밀번호"
+          },
+          "name": {
+            "type": "string",
+            "description": "사용자 이름"
+          }
+        }
+      },
+      "member-auth-signin-1190539043": {
+        "type": "object",
+        "properties": {
+          "msg": {
+            "type": "string",
+            "description": "메시지"
+          },
+          "code": {
+            "type": "number",
+            "description": "코드번호"
+          },
+          "data": {
+            "type": "string",
+            "description": "토큰값"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "성공여부"
+          }
+        }
+      },
+      "member-auth-signin278934565": {
+        "type": "object",
+        "properties": {
+          "password": {
+            "type": "string",
+            "description": "유저 비밀번호"
+          },
+          "email": {
+            "type": "string",
+            "description": "유저 아이디(이메일)"
+          }
+        }
+      },
+      "member-customer-1499051551": {
+        "type": "object",
+        "properties": {
+          "msg": {
+            "type": "string",
+            "description": "메시지"
+          },
+          "code": {
+            "type": "number",
+            "description": "코드번호"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "gender": {
+                "type": "string",
+                "description": "사용자 성별"
+              },
+              "name": {
+                "type": "string",
+                "description": "사용자 이름"
+              },
+              "age": {
+                "type": "number",
+                "description": "사용자 나이"
+              },
+              "email": {
+                "type": "string",
+                "description": "사용자 이메일(아이디)"
+              }
+            }
+          },
+          "success": {
+            "type": "boolean",
+            "description": "성공여부"
+          }
+        }
+      },
+      "member-customer-48225865": {
+        "type": "object",
+        "properties": {
+          "msg": {
+            "type": "string",
+            "description": "메시지"
+          },
+          "code": {
+            "type": "number",
+            "description": "코드번호"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "joinDate": {
+                "type": "string",
+                "description": "사용자 가입일자"
+              },
+              "createdDate": {
+                "type": "string",
+                "description": "생성일자"
+              },
+              "roles": {
+                "type": "array",
+                "description": "사용자 타입",
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "object"
+                    },
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                }
+              },
+              "name": {
+                "type": "string",
+                "description": "사용자 이름"
+              },
+              "id": {
+                "type": "number",
+                "description": "사용자 id"
+              },
+              "updatedDate": {
+                "type": "string",
+                "description": "수정일자"
+              },
+              "authorities": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "authority": {
+                      "type": "string",
+                      "description": "사용자 권한"
+                    }
+                  }
+                }
+              },
+              "age": {
+                "type": "number",
+                "description": "사용자 나이"
+              },
+              "email": {
+                "type": "string",
+                "description": "사용자 이메일(아이디)"
+              }
+            }
+          },
+          "success": {
+            "type": "boolean",
+            "description": "성공여부"
+          }
+        }
+      },
+      "member-userId-1032691858": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "사용자 이름"
+          },
+          "id": {
+            "type": "number",
+            "description": "사용자 id"
+          }
+        }
+      },
+      "member-store2134880610": {
+        "type": "object",
+        "properties": {
+          "msg": {
+            "type": "string",
+            "description": "메시지"
+          },
+          "code": {
+            "type": "number",
+            "description": "코드번호"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "사용자 이름"
+              },
+              "email": {
+                "type": "string",
+                "description": "사용자 이메일(아이디)"
+              }
+            }
+          },
+          "success": {
+            "type": "boolean",
+            "description": "성공여부"
+          }
+        }
+      },
+      "member-auth-signup1010847454": {
+        "type": "object",
+        "properties": {
+          "msg": {
+            "type": "string",
+            "description": "메시지"
+          },
+          "code": {
+            "type": "number",
+            "description": "코드번호"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "성공여부"
+          }
+        }
+      },
+      "member-auth-signup1306409953": {
+        "type": "object",
+        "properties": {
+          "password": {
+            "type": "string",
+            "description": "유저 비밀번호"
+          },
+          "gender": {
+            "type": "string",
+            "description": "성별"
+          },
+          "name": {
+            "type": "string",
+            "description": "유저 이름"
+          },
+          "userType": {
+            "type": "string",
+            "description": "유저 타입"
+          },
+          "age": {
+            "type": "number",
+            "description": "나이"
+          },
+          "email": {
+            "type": "string",
+            "description": "유저 아이디(이메일)"
+          }
+        }
+      },
+      "member-store-297999565": {
+        "type": "object",
+        "properties": {
+          "msg": {
+            "type": "string",
+            "description": "메시지"
+          },
+          "code": {
+            "type": "number",
+            "description": "코드번호"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "joinDate": {
+                "type": "string",
+                "description": "사용자 가입일자"
+              },
+              "createdDate": {
+                "type": "string",
+                "description": "생성일자"
+              },
+              "roles": {
+                "type": "array",
+                "description": "사용자 타입",
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "object"
+                    },
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                }
+              },
+              "name": {
+                "type": "string",
+                "description": "사용자 이름"
+              },
+              "id": {
+                "type": "number",
+                "description": "사용자 id"
+              },
+              "updatedDate": {
+                "type": "string",
+                "description": "수정일자"
+              },
+              "authorities": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "authority": {
+                      "type": "string",
+                      "description": "사용자 권한"
+                    }
+                  }
+                }
+              },
+              "email": {
+                "type": "string",
+                "description": "사용자 이메일(아이디)"
+              }
+            }
+          },
+          "success": {
+            "type": "boolean",
+            "description": "성공여부"
+          }
+        }
+      }
+    }
+  }
+}

--- a/member/docs/auction.json
+++ b/member/docs/auction.json
@@ -12,23 +12,219 @@
   ],
   "tags": [],
   "paths": {
-    "/auction/auctions": {
-      "get": {
+    "/auction": {
+      "post": {
         "tags": [
           "auction"
         ],
-        "operationId": "getAuctions",
+        "operationId": "registerAuction",
+        "requestBody": {
+          "content": {
+            "application/json;charset=UTF-8": {
+              "schema": {
+                "$ref": "#/components/schemas/auction486549215"
+              },
+              "examples": {
+                "registerAuction": {
+                  "value": "{\"title\":\"제목1\",\"content\":\"내용1\",\"maxPrice\":1000,\"minPrice\":10,\"userType\":\"Family\",\"reservation\":\"2021-06-22T18:37:35.306+00:00\",\"deadline\":\"2021-06-22T18:37:35.306+00:00\"}"
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "200",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/auction-auctions1317890811"
+                  "$ref": "#/components/schemas/auction-735543867"
+                },
+                "examples": {
+                  "registerAuction": {
+                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":{\"createdDate\":\"2021-06-22T18:37:35.773+00:00\",\"updatedDate\":\"2021-06-22T18:37:35.773+00:00\",\"auctionId\":4,\"title\":\"제목1\",\"content\":\"내용1\",\"maxPrice\":1000,\"minPrice\":10,\"status\":\"PROCEEDING\",\"userType\":\"Family\",\"reservation\":\"2021-06-22T18:37:35.306+00:00\",\"deadline\":\"2021-06-22T18:37:35.306+00:00\",\"userId\":1,\"auctioneers\":null,\"auctionStoreTypes\":null}}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auction/auctions": {
+      "get": {
+        "tags": [
+          "auction"
+        ],
+        "operationId": "auctionsgetAuctions",
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/auction-auctions-1927013758"
                 },
                 "examples": {
                   "getAuctions": {
-                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"list\":[{\"createdDate\":\"2021-06-20T17:17:25.014+00:00\",\"updatedDate\":\"2021-06-20T17:17:25.014+00:00\",\"auctionId\":6,\"title\":\"제목\",\"content\":\"내용\",\"maxPrice\":1000,\"minPrice\":10,\"status\":\"PROCEEDING\",\"userType\":\"Family\",\"reservation\":\"2021-06-20T17:17:25.014+00:00\",\"deadline\":\"2021-06-20T17:17:25.014+00:00\",\"userId\":\"1\",\"auctioneers\":null,\"auctionStoreTypes\":null}]}"
+                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"list\":[{\"createdDate\":\"2021-06-22T13:04:57.246+00:00\",\"updatedDate\":\"2021-06-22T13:04:57.246+00:00\",\"auctionId\":6,\"title\":\"제목\",\"content\":\"내용\",\"maxPrice\":1000,\"minPrice\":10,\"status\":\"PROCEEDING\",\"userType\":\"Family\",\"reservation\":\"2021-06-22T13:04:57.245+00:00\",\"deadline\":\"2021-06-22T13:04:57.245+00:00\",\"userId\":\"1\",\"auctioneers\":null,\"auctionStoreTypes\":null}]}"
+                  },
+                  "auctions": {
+                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"list\":[{\"createdDate\":\"2021-06-22T18:37:36.076+00:00\",\"updatedDate\":\"2021-06-22T18:37:36.076+00:00\",\"auctionId\":7,\"title\":\"제목\",\"content\":\"내용\",\"maxPrice\":1000,\"minPrice\":10,\"status\":\"PROCEEDING\",\"userType\":\"Family\",\"reservation\":\"2021-06-22T18:37:36.076+00:00\",\"deadline\":\"2021-06-22T18:37:36.076+00:00\",\"userId\":1,\"auctioneers\":null,\"auctionStoreTypes\":null}]}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auction/{auctionId}": {
+      "get": {
+        "tags": [
+          "auction"
+        ],
+        "operationId": "auction",
+        "parameters": [
+          {
+            "name": "auctionId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/auction-735543867"
+                },
+                "examples": {
+                  "auction": {
+                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":{\"createdDate\":\"2021-06-22T18:37:35.840+00:00\",\"updatedDate\":\"2021-06-22T18:37:35.840+00:00\",\"auctionId\":5,\"title\":\"제목\",\"content\":\"내용\",\"maxPrice\":1000,\"minPrice\":10,\"status\":\"PROCEEDING\",\"userType\":\"Family\",\"reservation\":\"2021-06-22T18:37:35.840+00:00\",\"deadline\":\"2021-06-22T18:37:35.840+00:00\",\"userId\":1,\"auctioneers\":null,\"auctionStoreTypes\":null}}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "auction"
+        ],
+        "operationId": "modifyAuction",
+        "parameters": [
+          {
+            "name": "auctionId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json;charset=UTF-8": {
+              "schema": {
+                "$ref": "#/components/schemas/auction486549215"
+              },
+              "examples": {
+                "modifyAuction": {
+                  "value": "{\"auctionId\":\"1\",\"title\":\"제목\",\"content\":\"수정\",\"maxPrice\":1000,\"minPrice\":10,\"userType\":\"Family\",\"reservation\":\"2021-06-22T18:37:34.575+00:00\",\"deadline\":\"2021-06-22T18:37:34.575+00:00\",\"userId\":\"1\"}"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/auction-735543867"
+                },
+                "examples": {
+                  "modifyAuction": {
+                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":{\"createdDate\":\"2021-06-22T18:37:34.587+00:00\",\"updatedDate\":\"2021-06-22T18:37:34.587+00:00\",\"auctionId\":1,\"title\":\"제목\",\"content\":\"수정\",\"maxPrice\":1000,\"minPrice\":10,\"status\":\"PROCEEDING\",\"userType\":\"Family\",\"reservation\":\"2021-06-22T18:37:34.575+00:00\",\"deadline\":\"2021-06-22T18:37:34.575+00:00\",\"userId\":1,\"auctioneers\":null,\"auctionStoreTypes\":null}}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "auction"
+        ],
+        "operationId": "deleteAuction",
+        "parameters": [
+          {
+            "name": "auctionId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/auction-auctionId40658993"
+                },
+                "examples": {
+                  "deleteAuction": {
+                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":true}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auction/{userId}/auctions": {
+      "get": {
+        "tags": [
+          "auction"
+        ],
+        "operationId": "getAuction",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/auction-userId-auctions4381044"
+                },
+                "examples": {
+                  "getAuction": {
+                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"list\":[{\"createdDate\":\"2021-06-22T18:37:35.920+00:00\",\"updatedDate\":\"2021-06-22T18:37:35.920+00:00\",\"auctionId\":6,\"title\":\"제목\",\"content\":\"내용\",\"maxPrice\":1000,\"minPrice\":10,\"status\":\"PROCEEDING\",\"userType\":\"Family\",\"reservation\":\"2021-06-22T18:37:35.920+00:00\",\"deadline\":\"2021-06-22T18:37:35.920+00:00\",\"userId\":1,\"auctioneers\":null,\"auctionStoreTypes\":null}]}"
                   }
                 }
               }
@@ -40,7 +236,7 @@
   },
   "components": {
     "schemas": {
-      "auction-auctions1317890811": {
+      "auction-userId-auctions4381044": {
         "type": "object",
         "properties": {
           "msg": {
@@ -62,56 +258,230 @@
               "properties": {
                 "updatedDate": {
                   "type": "string",
-                  "description": "Title of the book"
+                  "description": "공고 수정 일자"
                 },
                 "title": {
                   "type": "string",
-                  "description": "Title of the book"
+                  "description": "공고 제목"
                 },
                 "userId": {
-                  "type": "string",
-                  "description": "Title of the book"
+                  "type": "number",
+                  "description": "공고 작성자"
                 },
                 "content": {
                   "type": "string",
-                  "description": "Author of the book"
+                  "description": "공고 내용"
                 },
                 "auctionId": {
                   "type": "number",
-                  "description": "Title of the book"
+                  "description": "공고 ID"
                 },
                 "createdDate": {
                   "type": "string",
-                  "description": "Title of the book"
+                  "description": "공고 생성 일자"
                 },
                 "minPrice": {
                   "type": "number",
-                  "description": "Title of the book"
+                  "description": "공고 최소가"
                 },
                 "reservation": {
                   "type": "string",
-                  "description": "Title of the book"
+                  "description": "공고 예약 시간"
                 },
                 "userType": {
                   "type": "string",
-                  "description": "Title of the book"
+                  "description": "공고 사용자 유형(회식, 가족, 친구)"
                 },
                 "maxPrice": {
                   "type": "number",
-                  "description": "Title of the book"
+                  "description": "공고 최대가"
                 },
                 "deadline": {
                   "type": "string",
-                  "description": "Title of the book"
+                  "description": "공고 마감시간"
                 },
                 "status": {
                   "type": "string",
-                  "description": "Title of the book"
+                  "description": "공고 상태(진행중, 마감, 실패)"
                 }
               }
             }
           }
         }
+      },
+      "auction-auctions-1927013758": {
+        "type": "object",
+        "properties": {
+          "msg": {
+            "type": "string",
+            "description": "메시지"
+          },
+          "code": {
+            "type": "number",
+            "description": "코드번호"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "성공여부"
+          },
+          "list": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "updatedDate": {
+                  "type": "string",
+                  "description": "공고 수정 일자"
+                },
+                "title": {
+                  "type": "string",
+                  "description": "공고 제목"
+                },
+                "userId": {
+                  "description": "공고 작성자",
+                  "oneOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "content": {
+                  "type": "string",
+                  "description": "공고 내용"
+                },
+                "auctionId": {
+                  "type": "number",
+                  "description": "공고 ID"
+                },
+                "createdDate": {
+                  "type": "string",
+                  "description": "공고 생성 일자"
+                },
+                "minPrice": {
+                  "type": "number",
+                  "description": "공고 최소가"
+                },
+                "reservation": {
+                  "type": "string",
+                  "description": "공고 예약 시간"
+                },
+                "userType": {
+                  "type": "string",
+                  "description": "공고 사용자 유형(회식, 가족, 친구)"
+                },
+                "maxPrice": {
+                  "type": "number",
+                  "description": "공고 최대가"
+                },
+                "deadline": {
+                  "type": "string",
+                  "description": "공고 마감시간"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "공고 상태(진행중, 마감, 실패)"
+                }
+              }
+            }
+          }
+        }
+      },
+      "auction-auctionId40658993": {
+        "type": "object",
+        "properties": {
+          "msg": {
+            "type": "string",
+            "description": "메시지"
+          },
+          "code": {
+            "type": "number",
+            "description": "코드번호"
+          },
+          "data": {
+            "type": "boolean",
+            "description": "성공/실패"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "성공여부"
+          }
+        }
+      },
+      "auction-735543867": {
+        "type": "object",
+        "properties": {
+          "msg": {
+            "type": "string",
+            "description": "메시지"
+          },
+          "code": {
+            "type": "number",
+            "description": "코드번호"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "updatedDate": {
+                "type": "string",
+                "description": "공고 수정 일자"
+              },
+              "title": {
+                "type": "string",
+                "description": "공고 제목"
+              },
+              "userId": {
+                "type": "number",
+                "description": "공고 작성자"
+              },
+              "content": {
+                "type": "string",
+                "description": "공고 내용"
+              },
+              "auctionId": {
+                "type": "number",
+                "description": "공고 ID"
+              },
+              "createdDate": {
+                "type": "string",
+                "description": "공고 생성 일자"
+              },
+              "minPrice": {
+                "type": "number",
+                "description": "공고 최소가"
+              },
+              "reservation": {
+                "type": "string",
+                "description": "공고 예약 시간"
+              },
+              "userType": {
+                "type": "string",
+                "description": "공고 사용자 유형(회식, 가족, 친구)"
+              },
+              "maxPrice": {
+                "type": "number",
+                "description": "공고 최대가"
+              },
+              "deadline": {
+                "type": "string",
+                "description": "공고 마감시간"
+              },
+              "status": {
+                "type": "string",
+                "description": "공고 상태(진행중, 마감, 실패)"
+              }
+            }
+          },
+          "success": {
+            "type": "boolean",
+            "description": "성공여부"
+          }
+        }
+      },
+      "auction486549215": {
+        "type": "object"
       }
     }
   }

--- a/member/docs/auction.json
+++ b/member/docs/auction.json
@@ -1,0 +1,118 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "auction",
+    "description": "Demo project for Spring Boot",
+    "version": "0.0.1-SNAPSHOT"
+  },
+  "servers": [
+    {
+      "url": "http://localhost"
+    }
+  ],
+  "tags": [],
+  "paths": {
+    "/auction/auctions": {
+      "get": {
+        "tags": [
+          "auction"
+        ],
+        "operationId": "getAuctions",
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/auction-auctions1317890811"
+                },
+                "examples": {
+                  "getAuctions": {
+                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"list\":[{\"createdDate\":\"2021-06-20T17:17:25.014+00:00\",\"updatedDate\":\"2021-06-20T17:17:25.014+00:00\",\"auctionId\":6,\"title\":\"제목\",\"content\":\"내용\",\"maxPrice\":1000,\"minPrice\":10,\"status\":\"PROCEEDING\",\"userType\":\"Family\",\"reservation\":\"2021-06-20T17:17:25.014+00:00\",\"deadline\":\"2021-06-20T17:17:25.014+00:00\",\"userId\":\"1\",\"auctioneers\":null,\"auctionStoreTypes\":null}]}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "auction-auctions1317890811": {
+        "type": "object",
+        "properties": {
+          "msg": {
+            "type": "string",
+            "description": "메시지"
+          },
+          "code": {
+            "type": "number",
+            "description": "코드번호"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "성공여부"
+          },
+          "list": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "updatedDate": {
+                  "type": "string",
+                  "description": "Title of the book"
+                },
+                "title": {
+                  "type": "string",
+                  "description": "Title of the book"
+                },
+                "userId": {
+                  "type": "string",
+                  "description": "Title of the book"
+                },
+                "content": {
+                  "type": "string",
+                  "description": "Author of the book"
+                },
+                "auctionId": {
+                  "type": "number",
+                  "description": "Title of the book"
+                },
+                "createdDate": {
+                  "type": "string",
+                  "description": "Title of the book"
+                },
+                "minPrice": {
+                  "type": "number",
+                  "description": "Title of the book"
+                },
+                "reservation": {
+                  "type": "string",
+                  "description": "Title of the book"
+                },
+                "userType": {
+                  "type": "string",
+                  "description": "Title of the book"
+                },
+                "maxPrice": {
+                  "type": "number",
+                  "description": "Title of the book"
+                },
+                "deadline": {
+                  "type": "string",
+                  "description": "Title of the book"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "Title of the book"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/member/docs/auction.json
+++ b/member/docs/auction.json
@@ -1,48 +1,54 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "auction",
-    "description": "Demo project for Spring Boot",
-    "version": "0.0.1-SNAPSHOT"
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "auction",
+    "description" : "Demo project for Spring Boot",
+    "version" : "0.0.1-SNAPSHOT"
   },
-  "servers": [
-    {
-      "url": "http://localhost"
-    }
-  ],
-  "tags": [],
-  "paths": {
-    "/auction": {
-      "post": {
-        "tags": [
-          "auction"
-        ],
-        "operationId": "registerAuction",
-        "requestBody": {
-          "content": {
-            "application/json;charset=UTF-8": {
-              "schema": {
-                "$ref": "#/components/schemas/auction486549215"
+  "servers" : [ {
+    "url" : "http://localhost"
+  } ],
+  "tags" : [ ],
+  "paths" : {
+    "/auction" : {
+      "post" : {
+        "tags" : [ "auction" ],
+        "operationId" : "registerAuction",
+        "parameters" : [ {
+          "name" : "X-AUTH-TOKEN",
+          "in" : "header",
+          "description" : "토큰값",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwicm9sZXMiOlsiUk9MRV9VU0VSIl0sImlhdCI6MTYyNDQyMDI1MSwiZXhwIjoxNjI0NTA2NjUxfQ.beMJYnqZAF1WoTvumtmZiePrU4XmaHsqjBWrWvO2B60"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json;charset=UTF-8" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/auction-auctionId-auctioneer486549215"
               },
-              "examples": {
-                "registerAuction": {
-                  "value": "{\"title\":\"제목1\",\"content\":\"내용1\",\"maxPrice\":1000,\"minPrice\":10,\"userType\":\"Family\",\"reservation\":\"2021-06-22T18:37:35.306+00:00\",\"deadline\":\"2021-06-22T18:37:35.306+00:00\"}"
+              "examples" : {
+                "registerAuction" : {
+                  "value" : "{\"title\":\"제목1\",\"content\":\"내용1\",\"maxPrice\":1000,\"minPrice\":10,\"userType\":\"Family\",\"reservation\":\"2021-06-23T05:11:34.159+00:00\",\"deadline\":\"2021-06-23T05:11:34.159+00:00\"}"
                 }
               }
             }
           }
         },
-        "responses": {
-          "200": {
-            "description": "200",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/auction-735543867"
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/auction-735543867"
                 },
-                "examples": {
-                  "registerAuction": {
-                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":{\"createdDate\":\"2021-06-22T18:37:35.773+00:00\",\"updatedDate\":\"2021-06-22T18:37:35.773+00:00\",\"auctionId\":4,\"title\":\"제목1\",\"content\":\"내용1\",\"maxPrice\":1000,\"minPrice\":10,\"status\":\"PROCEEDING\",\"userType\":\"Family\",\"reservation\":\"2021-06-22T18:37:35.306+00:00\",\"deadline\":\"2021-06-22T18:37:35.306+00:00\",\"userId\":1,\"auctioneers\":null,\"auctionStoreTypes\":null}}"
+                "examples" : {
+                  "registerAuction" : {
+                    "value" : "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":{\"createdDate\":\"2021-06-23T05:11:34.181+00:00\",\"updatedDate\":\"2021-06-23T05:11:34.181+00:00\",\"auctionId\":4,\"title\":\"제목1\",\"content\":\"내용1\",\"maxPrice\":1000,\"minPrice\":10,\"status\":\"PROCEEDING\",\"userType\":\"Family\",\"reservation\":\"2021-06-23T05:11:34.159+00:00\",\"deadline\":\"2021-06-23T05:11:34.159+00:00\",\"userId\":1,\"auctioneers\":null,\"auctionStoreTypes\":null}}"
                   }
                 }
               }
@@ -51,26 +57,24 @@
         }
       }
     },
-    "/auction/auctions": {
-      "get": {
-        "tags": [
-          "auction"
-        ],
-        "operationId": "auctionsgetAuctions",
-        "responses": {
-          "200": {
-            "description": "200",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/auction-auctions-1927013758"
+    "/auction/auctions" : {
+      "get" : {
+        "tags" : [ "auction" ],
+        "operationId" : "auctionsgetAuctions",
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/auction-auctions-1927013758"
                 },
-                "examples": {
-                  "getAuctions": {
-                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"list\":[{\"createdDate\":\"2021-06-22T13:04:57.246+00:00\",\"updatedDate\":\"2021-06-22T13:04:57.246+00:00\",\"auctionId\":6,\"title\":\"제목\",\"content\":\"내용\",\"maxPrice\":1000,\"minPrice\":10,\"status\":\"PROCEEDING\",\"userType\":\"Family\",\"reservation\":\"2021-06-22T13:04:57.245+00:00\",\"deadline\":\"2021-06-22T13:04:57.245+00:00\",\"userId\":\"1\",\"auctioneers\":null,\"auctionStoreTypes\":null}]}"
+                "examples" : {
+                  "getAuctions" : {
+                    "value" : "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"list\":[{\"createdDate\":\"2021-06-22T13:04:57.246+00:00\",\"updatedDate\":\"2021-06-22T13:04:57.246+00:00\",\"auctionId\":6,\"title\":\"제목\",\"content\":\"내용\",\"maxPrice\":1000,\"minPrice\":10,\"status\":\"PROCEEDING\",\"userType\":\"Family\",\"reservation\":\"2021-06-22T13:04:57.245+00:00\",\"deadline\":\"2021-06-22T13:04:57.245+00:00\",\"userId\":\"1\",\"auctioneers\":null,\"auctionStoreTypes\":null}]}"
                   },
-                  "auctions": {
-                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"list\":[{\"createdDate\":\"2021-06-22T18:37:36.076+00:00\",\"updatedDate\":\"2021-06-22T18:37:36.076+00:00\",\"auctionId\":7,\"title\":\"제목\",\"content\":\"내용\",\"maxPrice\":1000,\"minPrice\":10,\"status\":\"PROCEEDING\",\"userType\":\"Family\",\"reservation\":\"2021-06-22T18:37:36.076+00:00\",\"deadline\":\"2021-06-22T18:37:36.076+00:00\",\"userId\":1,\"auctioneers\":null,\"auctionStoreTypes\":null}]}"
+                  "auctions" : {
+                    "value" : "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"list\":[{\"createdDate\":\"2021-06-23T05:11:34.544+00:00\",\"updatedDate\":\"2021-06-23T05:11:34.544+00:00\",\"auctionId\":7,\"title\":\"제목\",\"content\":\"내용\",\"maxPrice\":1000,\"minPrice\":10,\"status\":\"PROCEEDING\",\"userType\":\"Family\",\"reservation\":\"2021-06-23T05:11:34.544+00:00\",\"deadline\":\"2021-06-23T05:11:34.544+00:00\",\"userId\":1,\"auctioneers\":null,\"auctionStoreTypes\":null}]}"
                   }
                 }
               }
@@ -79,34 +83,30 @@
         }
       }
     },
-    "/auction/{auctionId}": {
-      "get": {
-        "tags": [
-          "auction"
-        ],
-        "operationId": "auction",
-        "parameters": [
-          {
-            "name": "auctionId",
-            "in": "path",
-            "description": "",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/auction/{auctionId}" : {
+      "get" : {
+        "tags" : [ "auction" ],
+        "operationId" : "auction",
+        "parameters" : [ {
+          "name" : "auctionId",
+          "in" : "path",
+          "description" : "",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "200",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/auction-735543867"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/auction-735543867"
                 },
-                "examples": {
-                  "auction": {
-                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":{\"createdDate\":\"2021-06-22T18:37:35.840+00:00\",\"updatedDate\":\"2021-06-22T18:37:35.840+00:00\",\"auctionId\":5,\"title\":\"제목\",\"content\":\"내용\",\"maxPrice\":1000,\"minPrice\":10,\"status\":\"PROCEEDING\",\"userType\":\"Family\",\"reservation\":\"2021-06-22T18:37:35.840+00:00\",\"deadline\":\"2021-06-22T18:37:35.840+00:00\",\"userId\":1,\"auctioneers\":null,\"auctionStoreTypes\":null}}"
+                "examples" : {
+                  "auction" : {
+                    "value" : "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":{\"createdDate\":\"2021-06-23T05:11:34.290+00:00\",\"updatedDate\":\"2021-06-23T05:11:34.290+00:00\",\"auctionId\":5,\"title\":\"제목\",\"content\":\"내용\",\"maxPrice\":1000,\"minPrice\":10,\"status\":\"PROCEEDING\",\"userType\":\"Family\",\"reservation\":\"2021-06-23T05:11:34.290+00:00\",\"deadline\":\"2021-06-23T05:11:34.290+00:00\",\"userId\":1,\"auctioneers\":null,\"auctionStoreTypes\":null}}"
                   }
                 }
               }
@@ -114,47 +114,52 @@
           }
         }
       },
-      "put": {
-        "tags": [
-          "auction"
-        ],
-        "operationId": "modifyAuction",
-        "parameters": [
-          {
-            "name": "auctionId",
-            "in": "path",
-            "description": "",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+      "put" : {
+        "tags" : [ "auction" ],
+        "operationId" : "modifyAuction",
+        "parameters" : [ {
+          "name" : "auctionId",
+          "in" : "path",
+          "description" : "",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json;charset=UTF-8": {
-              "schema": {
-                "$ref": "#/components/schemas/auction486549215"
+        }, {
+          "name" : "X-AUTH-TOKEN",
+          "in" : "header",
+          "description" : "토큰값",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwicm9sZXMiOlsiUk9MRV9VU0VSIl0sImlhdCI6MTYyNDQyMDI1MSwiZXhwIjoxNjI0NTA2NjUxfQ.beMJYnqZAF1WoTvumtmZiePrU4XmaHsqjBWrWvO2B60"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json;charset=UTF-8" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/auction-auctionId-auctioneer486549215"
               },
-              "examples": {
-                "modifyAuction": {
-                  "value": "{\"auctionId\":\"1\",\"title\":\"제목\",\"content\":\"수정\",\"maxPrice\":1000,\"minPrice\":10,\"userType\":\"Family\",\"reservation\":\"2021-06-22T18:37:34.575+00:00\",\"deadline\":\"2021-06-22T18:37:34.575+00:00\",\"userId\":\"1\"}"
+              "examples" : {
+                "modifyAuction" : {
+                  "value" : "{\"auctionId\":\"1\",\"title\":\"제목\",\"content\":\"수정\",\"maxPrice\":1000,\"minPrice\":10,\"userType\":\"Family\",\"reservation\":\"2021-06-23T05:11:33.489+00:00\",\"deadline\":\"2021-06-23T05:11:33.489+00:00\",\"userId\":\"1\"}"
                 }
               }
             }
           }
         },
-        "responses": {
-          "200": {
-            "description": "200",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/auction-735543867"
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/auction-735543867"
                 },
-                "examples": {
-                  "modifyAuction": {
-                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":{\"createdDate\":\"2021-06-22T18:37:34.587+00:00\",\"updatedDate\":\"2021-06-22T18:37:34.587+00:00\",\"auctionId\":1,\"title\":\"제목\",\"content\":\"수정\",\"maxPrice\":1000,\"minPrice\":10,\"status\":\"PROCEEDING\",\"userType\":\"Family\",\"reservation\":\"2021-06-22T18:37:34.575+00:00\",\"deadline\":\"2021-06-22T18:37:34.575+00:00\",\"userId\":1,\"auctioneers\":null,\"auctionStoreTypes\":null}}"
+                "examples" : {
+                  "modifyAuction" : {
+                    "value" : "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":{\"createdDate\":\"2021-06-23T05:11:33.498+00:00\",\"updatedDate\":\"2021-06-23T05:11:33.498+00:00\",\"auctionId\":1,\"title\":\"제목\",\"content\":\"수정\",\"maxPrice\":1000,\"minPrice\":10,\"status\":\"PROCEEDING\",\"userType\":\"Family\",\"reservation\":\"2021-06-23T05:11:33.489+00:00\",\"deadline\":\"2021-06-23T05:11:33.489+00:00\",\"userId\":1,\"auctioneers\":null,\"auctionStoreTypes\":null}}"
                   }
                 }
               }
@@ -162,33 +167,38 @@
           }
         }
       },
-      "delete": {
-        "tags": [
-          "auction"
-        ],
-        "operationId": "deleteAuction",
-        "parameters": [
-          {
-            "name": "auctionId",
-            "in": "path",
-            "description": "",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+      "delete" : {
+        "tags" : [ "auction" ],
+        "operationId" : "deleteAuction",
+        "parameters" : [ {
+          "name" : "auctionId",
+          "in" : "path",
+          "description" : "",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "200",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/auction-auctionId40658993"
+        }, {
+          "name" : "X-AUTH-TOKEN",
+          "in" : "header",
+          "description" : "토큰값",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwicm9sZXMiOlsiUk9MRV9VU0VSIl0sImlhdCI6MTYyNDQyMDI1MSwiZXhwIjoxNjI0NTA2NjUxfQ.beMJYnqZAF1WoTvumtmZiePrU4XmaHsqjBWrWvO2B60"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/auction-auctioneer-auctioneerId40658993"
                 },
-                "examples": {
-                  "deleteAuction": {
-                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":true}"
+                "examples" : {
+                  "deleteAuction" : {
+                    "value" : "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":true}"
                   }
                 }
               }
@@ -197,34 +207,211 @@
         }
       }
     },
-    "/auction/{userId}/auctions": {
-      "get": {
-        "tags": [
-          "auction"
-        ],
-        "operationId": "getAuction",
-        "parameters": [
-          {
-            "name": "userId",
-            "in": "path",
-            "description": "",
-            "required": true,
-            "schema": {
-              "type": "string"
+    "/auction/auctioneer/{auctioneerId}" : {
+      "put" : {
+        "tags" : [ "auction" ],
+        "operationId" : "modifyAuctioneer",
+        "parameters" : [ {
+          "name" : "auctioneerId",
+          "in" : "path",
+          "description" : "",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "X-AUTH-TOKEN",
+          "in" : "header",
+          "description" : "토큰값",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwicm9sZXMiOlsiUk9MRV9VU0VSIl0sImlhdCI6MTYyNDQyMDI1MSwiZXhwIjoxNjI0NTA2NjUxfQ.beMJYnqZAF1WoTvumtmZiePrU4XmaHsqjBWrWvO2B60"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json;charset=UTF-8" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/auction-auctionId-auctioneer486549215"
+              },
+              "examples" : {
+                "modifyAuctioneer" : {
+                  "value" : "{\"price\":10,\"menu\":\"수정\",\"content\":\"수정\"}"
+                }
+              }
             }
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "200",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/auction-userId-auctions4381044"
+        },
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/auction-auctionId-auctioneer512894856"
                 },
-                "examples": {
-                  "getAuction": {
-                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"list\":[{\"createdDate\":\"2021-06-22T18:37:35.920+00:00\",\"updatedDate\":\"2021-06-22T18:37:35.920+00:00\",\"auctionId\":6,\"title\":\"제목\",\"content\":\"내용\",\"maxPrice\":1000,\"minPrice\":10,\"status\":\"PROCEEDING\",\"userType\":\"Family\",\"reservation\":\"2021-06-22T18:37:35.920+00:00\",\"deadline\":\"2021-06-22T18:37:35.920+00:00\",\"userId\":1,\"auctioneers\":null,\"auctionStoreTypes\":null}]}"
+                "examples" : {
+                  "modifyAuctioneer" : {
+                    "value" : "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":{\"auctioneerId\":6,\"storeId\":1,\"menu\":\"menu\",\"price\":10,\"content\":\"수정\"}}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "auction" ],
+        "operationId" : "deleteAuctioneer",
+        "parameters" : [ {
+          "name" : "auctioneerId",
+          "in" : "path",
+          "description" : "",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "X-AUTH-TOKEN",
+          "in" : "header",
+          "description" : "토큰값",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwicm9sZXMiOlsiUk9MRV9VU0VSIl0sImlhdCI6MTYyNDQyMDI1MSwiZXhwIjoxNjI0NTA2NjUxfQ.beMJYnqZAF1WoTvumtmZiePrU4XmaHsqjBWrWvO2B60"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/auction-auctioneer-auctioneerId40658993"
+                },
+                "examples" : {
+                  "deleteAuctioneer" : {
+                    "value" : "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":true}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auction/{auctionId}/auctioneer" : {
+      "post" : {
+        "tags" : [ "auction" ],
+        "operationId" : "registerAuctioneer",
+        "parameters" : [ {
+          "name" : "auctionId",
+          "in" : "path",
+          "description" : "",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "X-AUTH-TOKEN",
+          "in" : "header",
+          "description" : "토큰값",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          },
+          "example" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwicm9sZXMiOlsiUk9MRV9VU0VSIl0sImlhdCI6MTYyNDQyMDI1MSwiZXhwIjoxNjI0NTA2NjUxfQ.beMJYnqZAF1WoTvumtmZiePrU4XmaHsqjBWrWvO2B60"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json;charset=UTF-8" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/auction-auctionId-auctioneer486549215"
+              },
+              "examples" : {
+                "registerAuctioneer" : {
+                  "value" : "{\"price\":10,\"menu\":\"menu\",\"content\":\"content\"}"
+                }
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/auction-auctionId-auctioneer512894856"
+                },
+                "examples" : {
+                  "registerAuctioneer" : {
+                    "value" : "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":{\"auctioneerId\":2,\"storeId\":1,\"menu\":\"menu\",\"price\":10,\"content\":\"content\"}}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auction/{auctionId}/auctioneers" : {
+      "get" : {
+        "tags" : [ "auction" ],
+        "operationId" : "auctioneers",
+        "parameters" : [ {
+          "name" : "auctionId",
+          "in" : "path",
+          "description" : "",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/auction-auctionId-auctioneers-832203831"
+                },
+                "examples" : {
+                  "auctioneers" : {
+                    "value" : "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"list\":[{\"auctioneerId\":4,\"storeId\":1,\"menu\":\"menu\",\"price\":1,\"content\":\"content\"},{\"auctioneerId\":5,\"storeId\":1,\"menu\":\"menu1\",\"price\":1,\"content\":\"content1\"}]}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auction/{userId}/auctions" : {
+      "get" : {
+        "tags" : [ "auction" ],
+        "operationId" : "getAuction",
+        "parameters" : [ {
+          "name" : "userId",
+          "in" : "path",
+          "description" : "",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/auction-userId-auctions4381044"
+                },
+                "examples" : {
+                  "getAuction" : {
+                    "value" : "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"list\":[{\"createdDate\":\"2021-06-23T05:11:34.424+00:00\",\"updatedDate\":\"2021-06-23T05:11:34.424+00:00\",\"auctionId\":6,\"title\":\"제목\",\"content\":\"내용\",\"maxPrice\":1000,\"minPrice\":10,\"status\":\"PROCEEDING\",\"userType\":\"Family\",\"reservation\":\"2021-06-23T05:11:34.423+00:00\",\"deadline\":\"2021-06-23T05:11:34.423+00:00\",\"userId\":1,\"auctioneers\":null,\"auctionStoreTypes\":null}]}"
                   }
                 }
               }
@@ -234,254 +421,338 @@
       }
     }
   },
-  "components": {
-    "schemas": {
-      "auction-userId-auctions4381044": {
-        "type": "object",
-        "properties": {
-          "msg": {
-            "type": "string",
-            "description": "메시지"
+  "components" : {
+    "schemas" : {
+      "auction-auctions-1927013758" : {
+        "type" : "object",
+        "properties" : {
+          "msg" : {
+            "type" : "string",
+            "description" : "메시지"
           },
-          "code": {
-            "type": "number",
-            "description": "코드번호"
+          "code" : {
+            "type" : "number",
+            "description" : "코드번호"
           },
-          "success": {
-            "type": "boolean",
-            "description": "성공여부"
+          "success" : {
+            "type" : "boolean",
+            "description" : "성공여부"
           },
-          "list": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "updatedDate": {
-                  "type": "string",
-                  "description": "공고 수정 일자"
+          "list" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "updatedDate" : {
+                  "type" : "string",
+                  "description" : "공고 수정 일자"
                 },
-                "title": {
-                  "type": "string",
-                  "description": "공고 제목"
+                "title" : {
+                  "type" : "string",
+                  "description" : "공고 제목"
                 },
-                "userId": {
-                  "type": "number",
-                  "description": "공고 작성자"
+                "userId" : {
+                  "description" : "공고 작성자",
+                  "oneOf" : [ {
+                    "type" : "number"
+                  }, {
+                    "type" : "string"
+                  } ]
                 },
-                "content": {
-                  "type": "string",
-                  "description": "공고 내용"
+                "content" : {
+                  "type" : "string",
+                  "description" : "공고 내용"
                 },
-                "auctionId": {
-                  "type": "number",
-                  "description": "공고 ID"
+                "auctionId" : {
+                  "type" : "number",
+                  "description" : "공고 ID"
                 },
-                "createdDate": {
-                  "type": "string",
-                  "description": "공고 생성 일자"
+                "createdDate" : {
+                  "type" : "string",
+                  "description" : "공고 생성 일자"
                 },
-                "minPrice": {
-                  "type": "number",
-                  "description": "공고 최소가"
+                "minPrice" : {
+                  "type" : "number",
+                  "description" : "공고 최소가"
                 },
-                "reservation": {
-                  "type": "string",
-                  "description": "공고 예약 시간"
+                "reservation" : {
+                  "type" : "string",
+                  "description" : "공고 예약 시간"
                 },
-                "userType": {
-                  "type": "string",
-                  "description": "공고 사용자 유형(회식, 가족, 친구)"
+                "userType" : {
+                  "type" : "string",
+                  "description" : "공고 사용자 유형(회식, 가족, 친구)"
                 },
-                "maxPrice": {
-                  "type": "number",
-                  "description": "공고 최대가"
+                "maxPrice" : {
+                  "type" : "number",
+                  "description" : "공고 최대가"
                 },
-                "deadline": {
-                  "type": "string",
-                  "description": "공고 마감시간"
+                "deadline" : {
+                  "type" : "string",
+                  "description" : "공고 마감시간"
                 },
-                "status": {
-                  "type": "string",
-                  "description": "공고 상태(진행중, 마감, 실패)"
+                "status" : {
+                  "type" : "string",
+                  "description" : "공고 상태(진행중, 마감, 실패)"
                 }
               }
             }
           }
         }
       },
-      "auction-auctions-1927013758": {
-        "type": "object",
-        "properties": {
-          "msg": {
-            "type": "string",
-            "description": "메시지"
+      "auction-userId-auctions4381044" : {
+        "type" : "object",
+        "properties" : {
+          "msg" : {
+            "type" : "string",
+            "description" : "메시지"
           },
-          "code": {
-            "type": "number",
-            "description": "코드번호"
+          "code" : {
+            "type" : "number",
+            "description" : "코드번호"
           },
-          "success": {
-            "type": "boolean",
-            "description": "성공여부"
+          "success" : {
+            "type" : "boolean",
+            "description" : "성공여부"
           },
-          "list": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "updatedDate": {
-                  "type": "string",
-                  "description": "공고 수정 일자"
+          "list" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "updatedDate" : {
+                  "type" : "string",
+                  "description" : "공고 수정 일자"
                 },
-                "title": {
-                  "type": "string",
-                  "description": "공고 제목"
+                "title" : {
+                  "type" : "string",
+                  "description" : "공고 제목"
                 },
-                "userId": {
-                  "description": "공고 작성자",
-                  "oneOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ]
+                "userId" : {
+                  "type" : "number",
+                  "description" : "공고 작성자"
                 },
-                "content": {
-                  "type": "string",
-                  "description": "공고 내용"
+                "content" : {
+                  "type" : "string",
+                  "description" : "공고 내용"
                 },
-                "auctionId": {
-                  "type": "number",
-                  "description": "공고 ID"
+                "auctionId" : {
+                  "type" : "number",
+                  "description" : "공고 ID"
                 },
-                "createdDate": {
-                  "type": "string",
-                  "description": "공고 생성 일자"
+                "createdDate" : {
+                  "type" : "string",
+                  "description" : "공고 생성 일자"
                 },
-                "minPrice": {
-                  "type": "number",
-                  "description": "공고 최소가"
+                "minPrice" : {
+                  "type" : "number",
+                  "description" : "공고 최소가"
                 },
-                "reservation": {
-                  "type": "string",
-                  "description": "공고 예약 시간"
+                "reservation" : {
+                  "type" : "string",
+                  "description" : "공고 예약 시간"
                 },
-                "userType": {
-                  "type": "string",
-                  "description": "공고 사용자 유형(회식, 가족, 친구)"
+                "userType" : {
+                  "type" : "string",
+                  "description" : "공고 사용자 유형(회식, 가족, 친구)"
                 },
-                "maxPrice": {
-                  "type": "number",
-                  "description": "공고 최대가"
+                "maxPrice" : {
+                  "type" : "number",
+                  "description" : "공고 최대가"
                 },
-                "deadline": {
-                  "type": "string",
-                  "description": "공고 마감시간"
+                "deadline" : {
+                  "type" : "string",
+                  "description" : "공고 마감시간"
                 },
-                "status": {
-                  "type": "string",
-                  "description": "공고 상태(진행중, 마감, 실패)"
+                "status" : {
+                  "type" : "string",
+                  "description" : "공고 상태(진행중, 마감, 실패)"
                 }
               }
             }
           }
         }
       },
-      "auction-auctionId40658993": {
-        "type": "object",
-        "properties": {
-          "msg": {
-            "type": "string",
-            "description": "메시지"
+      "auction-auctionId-auctioneer512894856" : {
+        "type" : "object",
+        "properties" : {
+          "msg" : {
+            "type" : "string",
+            "description" : "메시지"
           },
-          "code": {
-            "type": "number",
-            "description": "코드번호"
+          "code" : {
+            "type" : "number",
+            "description" : "코드번호"
           },
-          "data": {
-            "type": "boolean",
-            "description": "성공/실패"
-          },
-          "success": {
-            "type": "boolean",
-            "description": "성공여부"
-          }
-        }
-      },
-      "auction-735543867": {
-        "type": "object",
-        "properties": {
-          "msg": {
-            "type": "string",
-            "description": "메시지"
-          },
-          "code": {
-            "type": "number",
-            "description": "코드번호"
-          },
-          "data": {
-            "type": "object",
-            "properties": {
-              "updatedDate": {
-                "type": "string",
-                "description": "공고 수정 일자"
+          "data" : {
+            "type" : "object",
+            "properties" : {
+              "price" : {
+                "type" : "number",
+                "description" : "예상 가격"
               },
-              "title": {
-                "type": "string",
-                "description": "공고 제목"
+              "auctioneerId" : {
+                "type" : "number",
+                "description" : "Auctioneer ID"
               },
-              "userId": {
-                "type": "number",
-                "description": "공고 작성자"
+              "menu" : {
+                "type" : "string",
+                "description" : "추천 메뉴"
               },
-              "content": {
-                "type": "string",
-                "description": "공고 내용"
+              "storeId" : {
+                "type" : "number",
+                "description" : "참여 업체 id"
               },
-              "auctionId": {
-                "type": "number",
-                "description": "공고 ID"
-              },
-              "createdDate": {
-                "type": "string",
-                "description": "공고 생성 일자"
-              },
-              "minPrice": {
-                "type": "number",
-                "description": "공고 최소가"
-              },
-              "reservation": {
-                "type": "string",
-                "description": "공고 예약 시간"
-              },
-              "userType": {
-                "type": "string",
-                "description": "공고 사용자 유형(회식, 가족, 친구)"
-              },
-              "maxPrice": {
-                "type": "number",
-                "description": "공고 최대가"
-              },
-              "deadline": {
-                "type": "string",
-                "description": "공고 마감시간"
-              },
-              "status": {
-                "type": "string",
-                "description": "공고 상태(진행중, 마감, 실패)"
+              "content" : {
+                "type" : "string",
+                "description" : "내용"
               }
             }
           },
-          "success": {
-            "type": "boolean",
-            "description": "성공여부"
+          "success" : {
+            "type" : "boolean",
+            "description" : "성공여부"
           }
         }
       },
-      "auction486549215": {
-        "type": "object"
+      "auction-auctionId-auctioneers-832203831" : {
+        "type" : "object",
+        "properties" : {
+          "msg" : {
+            "type" : "string",
+            "description" : "메시지"
+          },
+          "code" : {
+            "type" : "number",
+            "description" : "코드번호"
+          },
+          "success" : {
+            "type" : "boolean",
+            "description" : "성공여부"
+          },
+          "list" : {
+            "type" : "array",
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "price" : {
+                  "type" : "number",
+                  "description" : "예상 가격"
+                },
+                "auctioneerId" : {
+                  "type" : "number",
+                  "description" : "Auctioneer ID"
+                },
+                "menu" : {
+                  "type" : "string",
+                  "description" : "추천 메뉴"
+                },
+                "storeId" : {
+                  "type" : "number",
+                  "description" : "참여 업체 id"
+                },
+                "content" : {
+                  "type" : "string",
+                  "description" : "내용"
+                }
+              }
+            }
+          }
+        }
+      },
+      "auction-auctioneer-auctioneerId40658993" : {
+        "type" : "object",
+        "properties" : {
+          "msg" : {
+            "type" : "string",
+            "description" : "메시지"
+          },
+          "code" : {
+            "type" : "number",
+            "description" : "코드번호"
+          },
+          "data" : {
+            "type" : "boolean",
+            "description" : "성공/실패"
+          },
+          "success" : {
+            "type" : "boolean",
+            "description" : "성공여부"
+          }
+        }
+      },
+      "auction-735543867" : {
+        "type" : "object",
+        "properties" : {
+          "msg" : {
+            "type" : "string",
+            "description" : "메시지"
+          },
+          "code" : {
+            "type" : "number",
+            "description" : "코드번호"
+          },
+          "data" : {
+            "type" : "object",
+            "properties" : {
+              "updatedDate" : {
+                "type" : "string",
+                "description" : "공고 수정 일자"
+              },
+              "title" : {
+                "type" : "string",
+                "description" : "공고 제목"
+              },
+              "userId" : {
+                "type" : "number",
+                "description" : "공고 작성자"
+              },
+              "content" : {
+                "type" : "string",
+                "description" : "공고 내용"
+              },
+              "auctionId" : {
+                "type" : "number",
+                "description" : "공고 ID"
+              },
+              "createdDate" : {
+                "type" : "string",
+                "description" : "공고 생성 일자"
+              },
+              "minPrice" : {
+                "type" : "number",
+                "description" : "공고 최소가"
+              },
+              "reservation" : {
+                "type" : "string",
+                "description" : "공고 예약 시간"
+              },
+              "userType" : {
+                "type" : "string",
+                "description" : "공고 사용자 유형(회식, 가족, 친구)"
+              },
+              "maxPrice" : {
+                "type" : "number",
+                "description" : "공고 최대가"
+              },
+              "deadline" : {
+                "type" : "string",
+                "description" : "공고 마감시간"
+              },
+              "status" : {
+                "type" : "string",
+                "description" : "공고 상태(진행중, 마감, 실패)"
+              }
+            }
+          },
+          "success" : {
+            "type" : "boolean",
+            "description" : "성공여부"
+          }
+        }
+      },
+      "auction-auctionId-auctioneer486549215" : {
+        "type" : "object"
       }
     }
   }

--- a/member/pom.xml
+++ b/member/pom.xml
@@ -16,6 +16,9 @@
     <properties>
         <java.version>11</java.version>
         <spring-cloud.version>2020.0.2</spring-cloud.version>
+        <restdocs-api-spec.version>0.10.0</restdocs-api-spec.version>
+        <restdocs-spec.version>0.19</restdocs-spec.version>
+        <asciidoctor.version>2.1.0</asciidoctor.version>
     </properties>
     <dependencies>
         <dependency>
@@ -66,6 +69,18 @@
             <artifactId>springfox-swagger-ui</artifactId>
             <version>2.9.2</version>
         </dependency>
+        <dependency>
+            <groupId>com.epages</groupId>
+            <artifactId>restdocs-api-spec-mockmvc</artifactId>
+            <version>${restdocs-api-spec.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.epages</groupId>
+            <artifactId>restdocs-api-spec</artifactId>
+            <version>${restdocs-api-spec.version}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- Feign Client -->
         <dependency>
             <groupId>org.springframework.cloud</groupId>
@@ -102,6 +117,11 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.restdocs</groupId>
+            <artifactId>spring-restdocs-asciidoctor</artifactId>
+            <version>${spring-restdocs.version}</version>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>
@@ -129,6 +149,55 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctor-maven-plugin</artifactId>
+                <version>${asciidoctor.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-docs</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <backend>html</backend>
+                            <doctype>login</doctype>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.springframework.restdocs</groupId>
+                        <artifactId>spring-restdocs-asciidoctor</artifactId>
+                        <version>${spring-restdocs.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin><!--Compile the life cycle of skipping test file inspection-->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.github.berkleytechnologyservices.restdocs-spec</groupId>
+                <artifactId>restdocs-spec-maven-plugin</artifactId>
+                <version>${restdocs-spec.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <specification>OPENAPI_V3</specification>
+                            <format>JSON</format>
+                            <outputDirectory>${project.build.directory}/classes/static/docs</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <repositories>
@@ -141,6 +210,10 @@
             </snapshots>
         </repository>
         <repository>
+            <id>jcenter</id>
+            <url>https://jcenter.bintray.com</url>
+        </repository>
+        <repository>
             <id>spring-snapshots</id>
             <name>Spring Snapshots</name>
             <url>https://repo.spring.io/snapshot</url>
@@ -150,6 +223,10 @@
         </repository>
     </repositories>
     <pluginRepositories>
+        <pluginRepository>
+            <id>jcenter</id>
+            <url>https://jcenter.bintray.com</url>
+        </pluginRepository>
         <pluginRepository>
             <id>spring-milestones</id>
             <name>Spring Milestones</name>

--- a/member/src/main/java/kr/or/dining_together/member/config/SwaggerConfig.java
+++ b/member/src/main/java/kr/or/dining_together/member/config/SwaggerConfig.java
@@ -26,11 +26,16 @@ public class SwaggerConfig {
 
 	@Bean
 	public Docket swaggerApi() {
-		return new Docket(DocumentationType.SWAGGER_2).apiInfo(swaggerInfo()).select()
-			.apis(RequestHandlerSelectors.basePackage("kr.or.dining_together.member.controller"))
-			.paths(PathSelectors.ant("/member/**"))
-			.build()
-			.useDefaultResponseMessages(false); // 기본으로 세팅되는 200,401,403,404 메시지를 표시 하지 않음
+		return new Docket(DocumentationType.SWAGGER_2)
+			.select()
+			.apis(RequestHandlerSelectors.any())
+			.paths(PathSelectors.any())
+			.build();
+		// return new Docket(DocumentationType.SWAGGER_2).apiInfo(swaggerInfo()).select()
+		// 	.apis(RequestHandlerSelectors.basePackage("kr.or.dining_together.member.controller"))
+		// 	.paths(PathSelectors.ant("/member/**"))
+		// 	.build()
+		// 	.useDefaultResponseMessages(false); // 기본으로 세팅되는 200,401,403,404 메시지를 표시 하지 않음
 	}
 
 	private ApiInfo swaggerInfo() {

--- a/member/src/main/java/kr/or/dining_together/member/dto/MenuDto.java
+++ b/member/src/main/java/kr/or/dining_together/member/dto/MenuDto.java
@@ -1,0 +1,25 @@
+package kr.or.dining_together.member.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@ApiModel(value = "MenuDto", description = "메뉴 불러오기")
+public class MenuDto {
+
+	@ApiModelProperty(value = "아이디(pkey)")
+	private long menuId;
+
+	@ApiModelProperty(value = "이름")
+	private String name;
+
+	@ApiModelProperty(value = "가격")
+	private int price;
+
+	@ApiModelProperty(value = "설명")
+	private String description;
+
+}

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/Menu.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/Menu.java
@@ -1,15 +1,16 @@
 package kr.or.dining_together.member.jpa.entity;
-
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
 import javax.persistence.PrimaryKeyJoinColumn;
+import javax.validation.constraints.Size;
 
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
@@ -22,12 +23,23 @@ import lombok.experimental.SuperBuilder;
 @PrimaryKeyJoinColumn(name = "user_id")
 @SuperBuilder
 @NoArgsConstructor
-public class Store extends User {
-	@ApiModelProperty(notes = "서류 제출 확인여부를 나타낸다")
-	@Column(columnDefinition = "boolean default false")
-	private Boolean documentChecked;
+public class Menu{
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private long menuId;
 
-	@OneToMany(mappedBy = "store")
-	private List<Menu> menus = new ArrayList<>();
+	@Column(length = 100)
+	@ApiModelProperty(notes = "메뉴 이름을 입력해 주세요")
+	private String name;
+
+	@Column(length = 100)
+	private int price;
+
+	@ApiModelProperty(value = "설명")
+	private String description;
+
+	@ManyToOne
+	@JoinColumn(name = "id")
+	private Store store;
 
 }

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/Menu.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/Menu.java
@@ -1,5 +1,4 @@
 package kr.or.dining_together.member.jpa.entity;
-import java.util.List;
 
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
@@ -10,7 +9,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.PrimaryKeyJoinColumn;
-import javax.validation.constraints.Size;
 
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
@@ -23,7 +21,7 @@ import lombok.experimental.SuperBuilder;
 @PrimaryKeyJoinColumn(name = "user_id")
 @SuperBuilder
 @NoArgsConstructor
-public class Menu{
+public class Menu {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private long menuId;

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/Store.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/Store.java
@@ -21,6 +21,9 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @NoArgsConstructor
 public class Store extends User {
+
+
+
 	@ApiModelProperty(notes = "서류 제출 확인여부를 나타낸다")
 	@Column(columnDefinition = "boolean default false")
 	private Boolean documentChecked;

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/Store.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/Store.java
@@ -22,8 +22,6 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 public class Store extends User {
 
-
-
 	@ApiModelProperty(notes = "서류 제출 확인여부를 나타낸다")
 	@Column(columnDefinition = "boolean default false")
 	private Boolean documentChecked;

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/Store.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/Store.java
@@ -6,8 +6,6 @@ import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.PrimaryKeyJoinColumn;
 

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/User.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/User.java
@@ -63,8 +63,6 @@ public class User implements UserDetails {
 	@Column(nullable = false, unique = true, length = 100)
 	private String email;
 
-	// @Column(length = 100)
-	// private String phoneNo;
 	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
 	@Column(length = 100)
 	@ApiModelProperty(notes = "패스워드을 입력해 주세요")
@@ -79,7 +77,6 @@ public class User implements UserDetails {
 
 	@Column(length = 100, columnDefinition = "varchar(100) default 'application'")
 	private String provider;
-
 
 	@ElementCollection(fetch = FetchType.EAGER)
 	@Builder.Default

--- a/member/src/main/java/kr/or/dining_together/member/service/UserService.java
+++ b/member/src/main/java/kr/or/dining_together/member/service/UserService.java
@@ -12,7 +12,6 @@ import kr.or.dining_together.member.advice.exception.DataSaveFailedException;
 import kr.or.dining_together.member.advice.exception.LoginFailedException;
 import kr.or.dining_together.member.advice.exception.PasswordNotMatchedException;
 import kr.or.dining_together.member.advice.exception.UserNotFoundException;
-import kr.or.dining_together.member.dto.SignUserDto;
 import kr.or.dining_together.member.dto.UserDto;
 import kr.or.dining_together.member.dto.UserIdDto;
 import kr.or.dining_together.member.jpa.entity.Customer;
@@ -56,13 +55,12 @@ public class UserService {
 	@Transactional
 	public void save(SignUpRequest signUpRequest) {
 		UserType userType = signUpRequest.getUserType();
-		SignUserDto userDto = signUpRequest.getSignUserDto();
 
 		if (userType == UserType.CUSTOMER) {
 			userRepository.save(Customer.builder()
-				.email(userDto.getEmail())
-				.password(passwordEncoder.encode(userDto.getPassword()))
-				.name(userDto.getName())
+				.email(signUpRequest.getEmail())
+				.password(passwordEncoder.encode(signUpRequest.getPassword()))
+				.name(signUpRequest.getName())
 				.gender(signUpRequest.getGender())
 				.age(signUpRequest.getAge())
 				.provider("application")
@@ -70,16 +68,16 @@ public class UserService {
 				.build());
 		} else if (userType == UserType.STORE) {
 			userRepository.save(Store.builder()
-				.email(userDto.getEmail())
-				.password(passwordEncoder.encode(userDto.getPassword()))
-				.name(userDto.getName())
+				.email(signUpRequest.getEmail())
+				.password(passwordEncoder.encode(signUpRequest.getPassword()))
+				.name(signUpRequest.getName())
 				.documentChecked(false)
 				.provider("application")
 				.roles(Collections.singletonList("ROLE_USER"))
 				.build());
 		}
 
-		if (userRepository.findByEmail(signUpRequest.getSignUserDto().getEmail()).isEmpty()) {
+		if (userRepository.findByEmail(signUpRequest.getEmail()).isEmpty()) {
 			throw new DataSaveFailedException();
 		}
 	}

--- a/member/src/main/java/kr/or/dining_together/member/vo/SignUpRequest.java
+++ b/member/src/main/java/kr/or/dining_together/member/vo/SignUpRequest.java
@@ -1,6 +1,5 @@
 package kr.or.dining_together.member.vo;
 
-import kr.or.dining_together.member.dto.SignUserDto;
 import kr.or.dining_together.member.jpa.entity.UserType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,7 +15,9 @@ import lombok.Setter;
 @NoArgsConstructor
 @Builder
 public class SignUpRequest {
-	private SignUserDto signUserDto;
+	private String email;
+	private String name;
+	private String password;
 	private UserType userType;
 	private int age;
 	private String gender;

--- a/member/src/main/resources/static/docs/openapi-3.0.json
+++ b/member/src/main/resources/static/docs/openapi-3.0.json
@@ -1,0 +1,178 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "member",
+    "description": "Demo project for Spring Boot",
+    "version": "0.0.1-SNAPSHOT"
+  },
+  "servers": [
+    {
+      "url": "http://localhost"
+    }
+  ],
+  "tags": [],
+  "paths": {
+    "/member/auth/signin": {
+      "post": {
+        "tags": [
+          "member"
+        ],
+        "operationId": "login",
+        "requestBody": {
+          "content": {
+            "application/json;charset=UTF-8": {
+              "schema": {
+                "$ref": "#/components/schemas/member-auth-signin278934565"
+              },
+              "examples": {
+                "login": {
+                  "value": "{\"email\":\"jifrozen@naver.com\",\"password\":\"test1111\"}"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/member-auth-signin-1190539043"
+                },
+                "examples": {
+                  "login": {
+                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\",\"data\":\"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJqaWZyb3plbkBuYXZlci5jb20iLCJyb2xlcyI6WyJST0xFX1VTRVIiXSwiaWF0IjoxNjI0MDM1ODM1LCJleHAiOjE2MjQxMjIyMzV9.79vEblqe5HZeY76TNcPofIo-znKxeCazO7NmozLiTAo\"}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/member/auth/signup": {
+      "post": {
+        "tags": [
+          "member"
+        ],
+        "operationId": "signup",
+        "requestBody": {
+          "content": {
+            "application/json;charset=UTF-8": {
+              "schema": {
+                "$ref": "#/components/schemas/member-auth-signup1306409953"
+              },
+              "examples": {
+                "signup": {
+                  "value": "{\"email\":\"jifrozen1@naver.com\",\"name\":\"문지언1\",\"password\":\"test2222\",\"userType\":\"CUSTOMER\",\"age\":23,\"gender\":\"FEMALE\"}"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/member-auth-signup1010847454"
+                },
+                "examples": {
+                  "signup": {
+                    "value": "{\"success\":true,\"code\":0,\"msg\":\"성공\"}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "member-auth-signin-1190539043": {
+        "type": "object",
+        "properties": {
+          "msg": {
+            "type": "string",
+            "description": "메시지"
+          },
+          "code": {
+            "type": "number",
+            "description": "코드번호"
+          },
+          "data": {
+            "type": "string",
+            "description": "토큰값"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "성공여부"
+          }
+        }
+      },
+      "member-auth-signin278934565": {
+        "type": "object",
+        "properties": {
+          "password": {
+            "type": "string",
+            "description": "유저 비밀번호"
+          },
+          "email": {
+            "type": "string",
+            "description": "유저 아이디(이메일)"
+          }
+        }
+      },
+      "member-auth-signup1010847454": {
+        "type": "object",
+        "properties": {
+          "msg": {
+            "type": "string",
+            "description": "메시지"
+          },
+          "code": {
+            "type": "number",
+            "description": "코드번호"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "성공여부"
+          }
+        }
+      },
+      "member-auth-signup1306409953": {
+        "type": "object",
+        "properties": {
+          "password": {
+            "type": "string",
+            "description": "유저 비밀번호"
+          },
+          "gender": {
+            "type": "string",
+            "description": "성별"
+          },
+          "name": {
+            "type": "string",
+            "description": "유저 이름"
+          },
+          "userType": {
+            "type": "string",
+            "description": "유저 타입"
+          },
+          "age": {
+            "type": "number",
+            "description": "나이"
+          },
+          "email": {
+            "type": "string",
+            "description": "유저 아이디(이메일)"
+          }
+        }
+      }
+    }
+  }
+}

--- a/member/src/test/java/kr/or/dining_together/member/controller/SignControllerTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/controller/SignControllerTest.java
@@ -124,7 +124,6 @@ public class SignControllerTest {
 			.accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 
-			//여기 고쳐야함
 			.andDo(document("signup",
 				requestFields(
 					fieldWithPath("email").description("유저 아이디(이메일)"),

--- a/member/src/test/java/kr/or/dining_together/member/controller/SignControllerTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/controller/SignControllerTest.java
@@ -1,7 +1,8 @@
 package kr.or.dining_together.member.controller;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.Collections;
@@ -10,9 +11,11 @@ import javax.transaction.Transactional;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.runner.RunWith;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
@@ -23,7 +26,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 
-import kr.or.dining_together.member.dto.SignUserDto;
 import kr.or.dining_together.member.jpa.entity.Customer;
 import kr.or.dining_together.member.jpa.entity.UserType;
 import kr.or.dining_together.member.jpa.repo.UserRepository;
@@ -32,6 +34,7 @@ import kr.or.dining_together.member.vo.SignUpRequest;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
+@AutoConfigureRestDocs
 @AutoConfigureMockMvc
 @Transactional
 public class SignControllerTest {
@@ -64,6 +67,7 @@ public class SignControllerTest {
 	}
 
 	@Test
+	@DisplayName("로그인 테스트")
 	public void signIn() throws Exception {
 		//given
 		String content = objectMapper.writeValueAsString(new LoginRequest("jifrozen@naver.com", "test1111"));
@@ -79,21 +83,31 @@ public class SignControllerTest {
 			.accept(MediaType.APPLICATION_JSON))
 			//then
 			.andExpect(status().isOk())
-			.andDo(print())
-			.andExpect(status().isOk());
+
+			.andDo(document("login",
+				requestFields(
+					fieldWithPath("email").description("유저 아이디(이메일)"),
+					fieldWithPath("password").description("유저 비밀번호")
+				),
+				responseFields(
+					fieldWithPath("success").description("성공여부"),
+					fieldWithPath("code").description("코드번호"),
+					fieldWithPath("msg").description("메시지"),
+					fieldWithPath("data").description("토큰값")
+				)
+			));
+
 	}
 
 	@Test
+	@DisplayName("회원가입 테스트")
 	public void signup() throws Exception {
 		//given
-		SignUserDto signUserDto = SignUserDto.builder()
+
+		SignUpRequest signUpRequest = SignUpRequest.builder()
 			.email("jifrozen1@naver.com")
 			.name("문지언1")
 			.password("test2222")
-			.build();
-
-		SignUpRequest signUpRequest = SignUpRequest.builder()
-			.signUserDto(signUserDto)
 			.userType(UserType.CUSTOMER)
 			.age(23)
 			.gender("FEMALE")
@@ -109,7 +123,23 @@ public class SignControllerTest {
 			.contentType(MediaType.APPLICATION_JSON)
 			.accept(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
-			.andDo(print());
+
+			//여기 고쳐야함
+			.andDo(document("signup",
+				requestFields(
+					fieldWithPath("email").description("유저 아이디(이메일)"),
+					fieldWithPath("name").description("유저 이름"),
+					fieldWithPath("password").description("유저 비밀번호"),
+					fieldWithPath("userType").description("유저 타입"),
+					fieldWithPath("age").description("나이"),
+					fieldWithPath("gender").description("성별")
+				),
+				responseFields(
+					fieldWithPath("success").description("성공여부"),
+					fieldWithPath("code").description("코드번호"),
+					fieldWithPath("msg").description("메시지")
+				)
+			));
 	}
 
 }

--- a/member/src/test/java/kr/or/dining_together/member/controller/UserControllerTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/controller/UserControllerTest.java
@@ -2,6 +2,7 @@ package kr.or.dining_together.member.controller;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
@@ -137,6 +138,9 @@ class UserControllerTest {
 			.andExpect(status().isOk())
 
 			.andDo(document("getCustomer",
+				requestHeaders(
+					headerWithName("X-AUTH-TOKEN").description(
+						"토큰값")),
 				responseFields(
 					fieldWithPath("success").description("성공여부"),
 					fieldWithPath("code").description("코드번호"),
@@ -166,6 +170,9 @@ class UserControllerTest {
 			.andExpect(status().isOk())
 
 			.andDo(document("getStore",
+				requestHeaders(
+					headerWithName("X-AUTH-TOKEN").description(
+						"토큰값")),
 				responseFields(
 					fieldWithPath("success").description("성공여부"),
 					fieldWithPath("code").description("코드번호"),
@@ -218,6 +225,9 @@ class UserControllerTest {
 			.andExpect(status().isOk())
 
 			.andDo(document("modifyCustomer",
+				requestHeaders(
+					headerWithName("X-AUTH-TOKEN").description(
+						"토큰값")),
 				requestFields(
 					fieldWithPath("password").description("유저 비밀번호"),
 					fieldWithPath("name").description("사용자 이름"),
@@ -254,6 +264,9 @@ class UserControllerTest {
 			.andExpect(status().isOk())
 
 			.andDo(document("modifyStore",
+				requestHeaders(
+					headerWithName("X-AUTH-TOKEN").description(
+						"토큰값")),
 				requestFields(
 					fieldWithPath("password").description("유저 비밀번호"),
 					fieldWithPath("name").description("사용자 이름")
@@ -311,6 +324,9 @@ class UserControllerTest {
 			.andExpect(status().isOk())
 
 			.andDo(document("delete",
+				requestHeaders(
+					headerWithName("X-AUTH-TOKEN").description(
+						"토큰값")),
 				responseFields(
 					fieldWithPath("success").description("성공여부"),
 					fieldWithPath("code").description("코드번호"),

--- a/member/src/test/java/kr/or/dining_together/member/controller/UserControllerTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/controller/UserControllerTest.java
@@ -1,6 +1,8 @@
 package kr.or.dining_together.member.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -17,14 +19,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.json.JacksonJsonParser;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -32,7 +35,9 @@ import kr.or.dining_together.member.jpa.entity.Customer;
 import kr.or.dining_together.member.jpa.entity.Store;
 import kr.or.dining_together.member.jpa.entity.User;
 import kr.or.dining_together.member.jpa.repo.UserRepository;
+import kr.or.dining_together.member.vo.CustomerProfileRequest;
 import kr.or.dining_together.member.vo.LoginRequest;
+import kr.or.dining_together.member.vo.StoreProfileRequest;
 
 /**
  * @package : kr.or.dining_together.member.controller
@@ -45,6 +50,7 @@ import kr.or.dining_together.member.vo.LoginRequest;
  **/
 @RunWith(SpringRunner.class)
 @SpringBootTest
+@AutoConfigureRestDocs
 @AutoConfigureMockMvc
 @Transactional
 class UserControllerTest {
@@ -123,12 +129,144 @@ class UserControllerTest {
 	}
 
 	@Test
-	void findUser() throws Exception {
-		mockMvc.perform(MockMvcRequestBuilders
-			.get("/member/user")
+	void getCustomer() throws Exception {
+		mockMvc.perform(RestDocumentationRequestBuilders
+			.get("/member/customer")
 			.header("X-AUTH-TOKEN", token))
 			.andDo(print())
-			.andExpect(status().isOk());
+			.andExpect(status().isOk())
+
+			.andDo(document("getCustomer",
+				responseFields(
+					fieldWithPath("success").description("성공여부"),
+					fieldWithPath("code").description("코드번호"),
+					fieldWithPath("msg").description("메시지"),
+					fieldWithPath("data.createdDate").description("생성일자"),
+					fieldWithPath("data.updatedDate").description("수정일자"),
+					fieldWithPath("data.id").description("사용자 id"),
+					fieldWithPath("data.email").description("사용자 이메일(아이디)"),
+					fieldWithPath("data.name").description("사용자 이름"),
+					fieldWithPath("data.joinDate").description("사용자 가입일자"),
+					fieldWithPath("data.provider").description("회원가입 제공자"),
+					fieldWithPath("data.age").description("사용자 나이"),
+					fieldWithPath("data.gender").description("사용자 성별"),
+					fieldWithPath("data.roles").description("사용자 타입"),
+					fieldWithPath("data.authorities.[].authority").description("사용자 권한")
+
+				)
+			));
+	}
+
+	@Test
+	void getStore() throws Exception {
+		mockMvc.perform(RestDocumentationRequestBuilders
+			.get("/member/store")
+			.header("X-AUTH-TOKEN", token1))
+			.andDo(print())
+			.andExpect(status().isOk())
+
+			.andDo(document("getStore",
+				responseFields(
+					fieldWithPath("success").description("성공여부"),
+					fieldWithPath("code").description("코드번호"),
+					fieldWithPath("msg").description("메시지"),
+					fieldWithPath("data.createdDate").description("생성일자"),
+					fieldWithPath("data.updatedDate").description("수정일자"),
+					fieldWithPath("data.id").description("사용자 id"),
+					fieldWithPath("data.email").description("사용자 이메일(아이디)"),
+					fieldWithPath("data.name").description("사용자 이름"),
+					fieldWithPath("data.joinDate").description("사용자 가입일자"),
+					fieldWithPath("data.provider").description("회원가입 제공자"),
+					fieldWithPath("data.roles").description("사용자 타입"),
+					fieldWithPath("data.authorities.[].authority").description("사용자 권한"),
+					fieldWithPath("data.documentChecked").description("서류 인증 여부"),
+					fieldWithPath("data.menus").description("업체 메뉴")
+
+				)
+			));
+	}
+
+	@Test
+	void getUserId() throws Exception {
+		mockMvc.perform(RestDocumentationRequestBuilders
+			.get("/member/userId")
+			.header("X-AUTH-TOKEN", token1))
+			.andDo(print())
+			.andExpect(status().isOk())
+
+			.andDo(document("getUserId",
+				responseFields(
+					fieldWithPath("id").description("사용자 id"),
+					fieldWithPath("name").description("사용자 이름")
+				)
+			));
+	}
+
+	@Test
+	void modifyCustomer() throws Exception {
+
+		String content = objectMapper.writeValueAsString(new CustomerProfileRequest("test1111", "test11", 1, "male"));
+
+		mockMvc.perform(RestDocumentationRequestBuilders.
+			put("/member/customer")
+			.content(content)
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
+			.header("X-AUTH-TOKEN", token))
+
+			.andDo(print())
+			.andExpect(status().isOk())
+
+			.andDo(document("modifyCustomer",
+				requestFields(
+					fieldWithPath("password").description("유저 비밀번호"),
+					fieldWithPath("name").description("사용자 이름"),
+					fieldWithPath("gender").description("사용자 성별"),
+					fieldWithPath("age").description("사용자 나이")
+				),
+				responseFields(
+					fieldWithPath("success").description("성공여부"),
+					fieldWithPath("code").description("코드번호"),
+					fieldWithPath("msg").description("메시지"),
+					fieldWithPath("data.email").description("사용자 이메일(아이디)"),
+					fieldWithPath("data.password").description("유저 비밀번호"),
+					fieldWithPath("data.name").description("사용자 이름"),
+					fieldWithPath("data.age").description("사용자 나이"),
+					fieldWithPath("data.gender").description("사용자 성별")
+
+				)
+			));
+	}
+
+	@Test
+	void modifyStore() throws Exception {
+
+		String content = objectMapper.writeValueAsString(new StoreProfileRequest("test1111", "test11"));
+
+		mockMvc.perform(RestDocumentationRequestBuilders.
+			put("/member/store")
+			.content(content)
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
+			.header("X-AUTH-TOKEN", token))
+
+			.andDo(print())
+			.andExpect(status().isOk())
+
+			.andDo(document("modifyStore",
+				requestFields(
+					fieldWithPath("password").description("유저 비밀번호"),
+					fieldWithPath("name").description("사용자 이름")
+				),
+				responseFields(
+					fieldWithPath("success").description("성공여부"),
+					fieldWithPath("code").description("코드번호"),
+					fieldWithPath("msg").description("메시지"),
+					fieldWithPath("data.email").description("사용자 이메일(아이디)"),
+					fieldWithPath("data.password").description("유저 비밀번호"),
+					fieldWithPath("data.name").description("사용자 이름")
+				)
+			));
 	}
 
 	// @Test
@@ -166,11 +304,19 @@ class UserControllerTest {
 	void delete() throws Exception {
 		Optional<User> user = userRepository.findByEmail("jifrozen@naver.com");
 		assertTrue(user.isPresent());
-		mockMvc.perform(MockMvcRequestBuilders
+		mockMvc.perform(RestDocumentationRequestBuilders
 			.delete("/member/user")
 			.header("X-AUTH-TOKEN", token))
 			.andDo(print())
-			.andExpect(status().isOk());
+			.andExpect(status().isOk())
+
+			.andDo(document("delete",
+				responseFields(
+					fieldWithPath("success").description("성공여부"),
+					fieldWithPath("code").description("코드번호"),
+					fieldWithPath("msg").description("메시지")
+				)
+			));
 		assertTrue(userRepository.findByEmail("jifrozen@naver.com").isEmpty());
 	}
 

--- a/member/src/test/java/kr/or/dining_together/member/service/StoreService.java
+++ b/member/src/test/java/kr/or/dining_together/member/service/StoreService.java
@@ -1,0 +1,4 @@
+package kr.or.dining_together.member.service;
+
+public class StoreService {
+}

--- a/member/src/test/java/kr/or/dining_together/member/service/UserServiceTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/service/UserServiceTest.java
@@ -15,7 +15,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import kr.or.dining_together.member.dto.SignUserDto;
 import kr.or.dining_together.member.dto.UserIdDto;
 import kr.or.dining_together.member.jpa.entity.Customer;
 import kr.or.dining_together.member.jpa.entity.Store;
@@ -71,14 +70,11 @@ public class UserServiceTest {
 
 	@Test
 	public void signUpTest() {
-		SignUserDto signUserDto = SignUserDto.builder()
+
+		SignUpRequest signUpRequest = SignUpRequest.builder()
 			.email("qja9605@naver.com")
 			.name("신태범")
 			.password("1234")
-			.build();
-
-		SignUpRequest signUpRequest = SignUpRequest.builder()
-			.signUserDto(signUserDto)
 			.userType(UserType.CUSTOMER)
 			.age(24)
 			.gender("MALE")


### PR DESCRIPTION
# MSA 환경에서 API 문서 통합 관리 ( Spring restDocs와 Swagger UI 조합)
![image](https://user-images.githubusercontent.com/62784314/122984010-8653cb80-d3d7-11eb-9af7-e375d3af6187.png)

![image](https://user-images.githubusercontent.com/62784314/122984025-894ebc00-d3d7-11eb-90da-01cf8541c342.png)

우선 local 환경에서는 잘 보입니다.
<img width="592" alt="image" src="https://user-images.githubusercontent.com/62784314/122985718-7937dc00-d3d9-11eb-8fc1-e608efe2350b.png">
선택박스로 구분해서 선택합니다.

## 해결해야하는 부분
1. Member 서비스에서 이메일 컨트롤러는 redis 추가되어 바뀌는 부분이 있어 아직 못했습니다....혹시 redis 완료하시면 Controller 테스트부분 작성해주실 수 잇나요??
2. Auctioneer( 공고 참여 업체) 부분 아직 Member 와 연동을 못해 Feign client 작성 못했습니다. 업체 CRUD 완성하면 작성 완료하겠습니다.
3. 빌드와 배포 자동화는 어차피 진행 해야하는 작업이기 때문에 미리 공부하고 적용할 수 있으면 적용하겠습니다.
4. Auction 은 Customer 권한만 작성할수있고 Auctioneer는 Store만 작성할 수 있게 해야하는데 Security 는 Member에만 있어 설정파일을 이용하지 못하고 제가 생각한 방식은 Feign client 로 권한을 불러와 구분해주는 식으로 작성하는 방식인데 혹시 다른 좋은 해결방법이 있으면 조언 부탁드립니다.


참고 문서
https://taetaetae.github.io/posts/a-combination-of-swagger-and-spring-restdocs/

https://blog.naver.com/qjawnswkd/222340413113

https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#features.testing.spring-boot-applications.autoconfigured-spring-restdocs

https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/

https://www.youtube.com/watch?v=qguXHW0s8RY

https://forward.nhn.com/session/3
