### PR TITLE
[Feat] 사용자 프로필 사진 && 업체 서류 인증

### DIFF
--- a/member/src/main/java/kr/or/dining_together/member/advice/ExceptionAdvice.java
+++ b/member/src/main/java/kr/or/dining_together/member/advice/ExceptionAdvice.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import kr.or.dining_together.member.advice.exception.AuthenticationEntryPointException;
 import kr.or.dining_together.member.advice.exception.ComunicationException;
 import kr.or.dining_together.member.advice.exception.DataSaveFailedException;
+import kr.or.dining_together.member.advice.exception.FileNotFoundException;
 import kr.or.dining_together.member.advice.exception.LoginFailedException;
 import kr.or.dining_together.member.advice.exception.PasswordNotMatchedException;
 import kr.or.dining_together.member.advice.exception.ResourceNotExistException;
@@ -87,5 +88,12 @@ public class ExceptionAdvice {
 	public CommonResult resourceNotExistException(HttpServletRequest request,
 		ResourceNotExistException e) {
 		return responseService.getFailResult(HttpStatus.NOT_FOUND.value(), "요청한 자원이 존재하지 않습니다.");
+	}
+
+	@ExceptionHandler(FileNotFoundException.class)
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	public CommonResult fileNotFoundException(HttpServletRequest request,
+		FileNotFoundException e) {
+		return responseService.getFailResult(HttpStatus.NOT_FOUND.value(), "파일이 존재하지 않습니다.");
 	}
 }

--- a/member/src/main/java/kr/or/dining_together/member/advice/exception/FileNotFoundException.java
+++ b/member/src/main/java/kr/or/dining_together/member/advice/exception/FileNotFoundException.java
@@ -1,0 +1,15 @@
+package kr.or.dining_together.member.advice.exception;
+
+public class FileNotFoundException extends RuntimeException {
+	public FileNotFoundException() {
+		super();
+	}
+
+	public FileNotFoundException(String message) {
+		super(message);
+	}
+
+	public FileNotFoundException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/member/src/main/java/kr/or/dining_together/member/controller/StoreController.java
+++ b/member/src/main/java/kr/or/dining_together/member/controller/StoreController.java
@@ -1,0 +1,63 @@
+package kr.or.dining_together.member.controller;
+
+import java.io.File;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import kr.or.dining_together.member.advice.exception.UserNotFoundException;
+import kr.or.dining_together.member.jpa.entity.Store;
+import kr.or.dining_together.member.jpa.repo.StoreRepository;
+import kr.or.dining_together.member.model.CommonResult;
+import kr.or.dining_together.member.service.FileService;
+import kr.or.dining_together.member.service.ResponseService;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @package : kr.or.dining_together.member.controller
+ * @name: StoreController.java
+ * @date : 2021/06/30 2:28 오전
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description :
+ * @modified :
+ **/
+@Api(tags = {"5. Store"})
+@RequiredArgsConstructor
+@RestController
+@RequestMapping(value = "/member")
+public class StoreController {
+
+	private final StoreRepository storeRepository;
+	private final FileService fileService;
+	private final ResponseService responseService;
+
+	@ApiOperation(value = "서류 이미지 등록")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name = "X-AUTH-TOKEN", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")
+	})
+	@PostMapping(value = "/store/document")
+	public CommonResult saveFile(
+		@RequestBody @ApiParam(value = "서류 사진", required = true) MultipartFile file) {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		String email = authentication.getName();
+		Store user = storeRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
+		if (user.getPath() != null) {
+			new File(user.getPath()).delete();
+		}
+		String fileName = user.getId() + "_document";
+		fileService.save(file, fileName, "store/document");
+		return responseService.getSuccessResult();
+	}
+
+}

--- a/member/src/main/java/kr/or/dining_together/member/jpa/entity/User.java
+++ b/member/src/main/java/kr/or/dining_together/member/jpa/entity/User.java
@@ -72,6 +72,7 @@ public class User implements UserDetails {
 	@Size(min = 2, message = "Name은 2글자 이상 입력.")
 	@ApiModelProperty(notes = "사용자 이름을 입력해 주세요")
 	private String name;
+	private String path;
 	@Past
 	@ApiModelProperty(notes = "등록일 정보입니다. 자동으로 입력됩니다.")
 	private Date joinDate;
@@ -142,6 +143,10 @@ public class User implements UserDetails {
 	public void update(String password, String name) {
 		this.password = password;
 		this.name = name;
+	}
+
+	public void imageUpdate(String path) {
+		this.path = path;
 	}
 
 }

--- a/member/src/main/java/kr/or/dining_together/member/service/FavoritesService.java
+++ b/member/src/main/java/kr/or/dining_together/member/service/FavoritesService.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Service;
 
 import kr.or.dining_together.member.advice.exception.DataSaveFailedException;
 import kr.or.dining_together.member.advice.exception.UserNotFoundException;
-import kr.or.dining_together.member.jpa.entity.Customer;
 import kr.or.dining_together.member.jpa.entity.CustomerFavorites;
 import kr.or.dining_together.member.jpa.entity.StoreFavorites;
 import kr.or.dining_together.member.jpa.entity.User;
@@ -26,19 +25,19 @@ public class FavoritesService {
 	private final UserService userService;
 
 	public List<CustomerFavorites> getCustomerFavoritesAll(String email) throws Throwable {
-		User user= (User)userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
+		User user = (User)userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
 		List<CustomerFavorites> customerFavorites = customerFavoritesRepository.findAllByUserId(user.getId());
 		return customerFavorites;
 	}
 
 	public List<StoreFavorites> getStoreFavoritesAll(String email) throws Throwable {
-		User user= (User)userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
+		User user = (User)userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
 		List<StoreFavorites> storeFavorites = storeFavoritesRepository.findAllByUserId(user.getId());
 		return storeFavorites;
 	}
 
 	public void saveFavorites(String email, FavoritesRequest favoritesRequest) throws Throwable {
-		User user= (User)userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
+		User user = (User)userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
 		String requestType = favoritesRequest.getFavoritesType();
 		Long objectId = favoritesRequest.getObjectId();
 
@@ -67,7 +66,7 @@ public class FavoritesService {
 	}
 
 	public void deleteFavorite(String email, FavoritesRequest favoritesRequest) throws Throwable {
-		User user= (User)userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
+		User user = (User)userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
 		String requestType = favoritesRequest.getFavoritesType();
 		Long objectId = favoritesRequest.getObjectId();
 

--- a/member/src/main/java/kr/or/dining_together/member/service/FileService.java
+++ b/member/src/main/java/kr/or/dining_together/member/service/FileService.java
@@ -1,0 +1,60 @@
+package kr.or.dining_together.member.service;
+
+import java.io.File;
+import java.io.IOException;
+
+import javax.transaction.Transactional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FileService {
+
+	public String save(MultipartFile file, String name, String type) {
+		StringBuilder sb = new StringBuilder();
+		File dest = null;
+		// file image 가 없을 경우
+		if (file.isEmpty()) {
+			sb.append("none");
+		}
+		if (!file.isEmpty()) {
+			// jpeg, png, gif 파일들만 받아서 처리할 예정
+			String contentType = file.getContentType();
+			String originalFileExtension = null;
+			// 확장자 명이 없으면 이 파일은 잘 못 된 것이다
+			if (ObjectUtils.isEmpty(contentType)) {
+				sb.append("none");
+			}
+			if (!ObjectUtils.isEmpty(contentType)) {
+				if (contentType.contains("image/jpeg")) {
+					originalFileExtension = ".jpg";
+				} else if (contentType.contains("image/png")) {
+					originalFileExtension = ".png";
+				} else if (contentType.contains("image/gif")) {
+					originalFileExtension = ".gif";
+				}
+				sb.append(name + originalFileExtension);
+			}
+
+			dest = new File(
+				"/Users/jifrozen/project/Dining-together/Backend/member/upload/" + type + "/" + sb.toString());
+			try {
+				file.transferTo(dest);
+			} catch (IllegalStateException e) {
+				e.printStackTrace();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+			// db에 파일 위치랑 번호 등록
+		}
+		return dest.getPath();
+
+	}
+
+}

--- a/member/src/main/java/kr/or/dining_together/member/service/StoreService.java
+++ b/member/src/main/java/kr/or/dining_together/member/service/StoreService.java
@@ -1,0 +1,4 @@
+package kr.or.dining_together.member.service;
+
+public class StoreService {
+}

--- a/member/src/main/java/kr/or/dining_together/member/vo/MenuRequest.java
+++ b/member/src/main/java/kr/or/dining_together/member/vo/MenuRequest.java
@@ -20,4 +20,6 @@ public class MenuRequest {
 	private int price;
 
 	private String description;
+
+	private String path;
 }

--- a/member/src/test/java/kr/or/dining_together/member/controller/UserControllerTest.java
+++ b/member/src/test/java/kr/or/dining_together/member/controller/UserControllerTest.java
@@ -4,6 +4,7 @@ import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -24,6 +25,7 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -155,6 +157,7 @@ class UserControllerTest {
 					fieldWithPath("data.age").description("사용자 나이"),
 					fieldWithPath("data.gender").description("사용자 성별"),
 					fieldWithPath("data.roles").description("사용자 타입"),
+					fieldWithPath("data.path").description("사용자 사진"),
 					fieldWithPath("data.authorities.[].authority").description("사용자 권한")
 
 				)
@@ -187,6 +190,7 @@ class UserControllerTest {
 					fieldWithPath("data.roles").description("사용자 타입"),
 					fieldWithPath("data.authorities.[].authority").description("사용자 권한"),
 					fieldWithPath("data.documentChecked").description("서류 인증 여부"),
+					fieldWithPath("data.path").description("사용자 사진"),
 					fieldWithPath("data.menus").description("업체 메뉴"),
 					fieldWithPath("data.phoneNum").description("업체 메뉴"),
 					fieldWithPath("data.addr").description("업체 메뉴"),
@@ -283,6 +287,35 @@ class UserControllerTest {
 					fieldWithPath("data.name").description("사용자 이름")
 				)
 			));
+	}
+
+	@Test
+	void saveFile() throws Exception {
+		MockMultipartFile file
+			= new MockMultipartFile(
+			"file",
+			"hello.jpg",
+			MediaType.IMAGE_JPEG_VALUE,
+			"Hello, World!".getBytes()
+		);
+		mockMvc.perform(
+			RestDocumentationRequestBuilders.fileUpload("/member/image").file(file)
+				.header("X-AUTH-TOKEN", token))
+			.andDo(print())
+			.andExpect(status().isOk())
+
+			.andDo(document("saveFile",
+				requestHeaders(
+					headerWithName("X-AUTH-TOKEN").description(
+						"토큰값")),
+				requestParts(
+					partWithName("file").description("The file to upload")
+				),
+				responseFields(
+					fieldWithPath("success").description("성공여부"),
+					fieldWithPath("code").description("코드번호"),
+					fieldWithPath("msg").description("메시지")
+				)));
 	}
 
 	@Test


### PR DESCRIPTION
# 사용자 프로필 사진 && 업체 서류 인증
<img width="1189" alt="image" src="https://user-images.githubusercontent.com/62784314/123896570-c77e4980-d99c-11eb-9520-9cd76113dd76.png">

![image](https://user-images.githubusercontent.com/62784314/123896588-cf3dee00-d99c-11eb-80a7-8faa3c599d91.png)
 
파일 이름
사용자 프로필 사진 - 사용자 id_photo
업체 가게 사진 - 업체id_store
업체 서류 - 업체 id_document

이미지 처리 코드는 이전에 올렸던 코드와 똑같습니다.
이미지 처리 FileService로 따로 둬 재사용성을 높였습니다.

1. 서류 인증을 TRUE로 바뀌는 지점(?) 언제인지?
1) 서류 올리면서 True 변환
2) admin 인증 절차 후 변환